### PR TITLE
Fix for not properly invoking g++ and clang++ when compiling C++ source files.

### DIFF
--- a/scripts/tundra/tools/clang-osx.lua
+++ b/scripts/tundra/tools/clang-osx.lua
@@ -22,7 +22,7 @@ function apply(env, options)
 
 	env:set_many {
 		["CC"] = "clang",
-		["C++"] = "clang",
+		["C++"] = "clang++",
 		["LD"] = "clang",
 	}
 end

--- a/scripts/tundra/tools/gcc.lua
+++ b/scripts/tundra/tools/gcc.lua
@@ -38,7 +38,7 @@ function apply(env, options)
 		["CCOPTS"] = "",
 		["CXXOPTS"] = "",
 		["CCCOM"] = "$(CC) $(_OS_CCOPTS) -c $(CPPDEFS:p-D) $(CPPPATH:f:p-I) $(CCOPTS) $(CCOPTS_$(CURRENT_VARIANT:u)) -o $(@) $(<)",
-		["CXXCOM"] = "$(CC) $(_OS_CXXOPTS) -c $(CPPDEFS:p-D) $(CPPPATH:f:p-I) $(CXXOPTS) $(CXXOPTS_$(CURRENT_VARIANT:u)) -o $(@) $(<)",
+		["CXXCOM"] = "$(C++) $(_OS_CXXOPTS) -c $(CPPDEFS:p-D) $(CPPPATH:f:p-I) $(CXXOPTS) $(CXXOPTS_$(CURRENT_VARIANT:u)) -o $(@) $(<)",
 		["PROGOPTS"] = "",
 		["PROGCOM"] = "$(LD) $(PROGOPTS) $(LIBPATH:p-L) $(LIBS:p-l) -o $(@) $(<)",
 		["PROGPREFIX"] = "",


### PR DESCRIPTION
- Modified the clang-osx toolset to use "clang++" for the C++ compiler, instead of simply "clang".
- Modified the gcc toolset's "CXXCOM" environment variable so that it properly invokes the $(C++) tool instead of $(CC).
