### PR TITLE
Bugfix for ReplaceEnv when replacing an environment variable with a list of values.

### DIFF
--- a/scripts/tundra/boot.lua
+++ b/scripts/tundra/boot.lua
@@ -352,7 +352,7 @@ local function setup_env(env, tuple, build_id)
 				if Options.VeryVerbose then
 					printf("Env Replace %s => %s", util.tostring(val), util.tostring(list))
 				end
-				env:replace(key, subvalue)
+				env:replace(key, list)
 			else
 				env:replace(key, val)
 			end


### PR DESCRIPTION
This is a fix for a critical bug/typo in the setup_env function in boot.lua when replacing an environment variable with a list of values via the ReplaceEnv scripting call. For example, when doing the following in a tundra.lua file:

Config = { ..., ReplaceEnv = { LIBS = { "c", "stdc++" }, ... }

It resulted in this runtime error: "scripts/tundra/boot.lua:355: variable 'subvalue' is not declared"
