### PR TITLE
Make building shared libraries with GCC work out of the box on Linux and the BSDs

### DIFF
--- a/scripts/tundra/tools/gcc.lua
+++ b/scripts/tundra/tools/gcc.lua
@@ -44,5 +44,8 @@ function apply(env, options)
 		["PROGPREFIX"] = "",
 		["LIBOPTS"] = "",
 		["LIBCOM"] = "$(LIB) -rs $(LIBOPTS) $(@) $(<)",
+		["SHLIBPREFIX"] = "lib",
+		["SHLIBOPTS"] = "-shared",
+		["SHLIBCOM"] = "$(LD) $(SHLIBOPTS) $(LIBPATH:p-L) $(LIBS:p-l) -o $(@) $(<)",
 	}
 end


### PR DESCRIPTION
This patch adds rudimentary support for building native shared libraries via the SharedLibrary call to the base GCC toolset for Linux and the BSDs.

I was trying to get shared libraries building and noticed that Tundra didn't quite support it out of the box on Linux. At first, I thought about just adding a gcc-linux.lua sub-tool that derived from gcc.lua, much like how gcc-osx.lua is currently implemented. But then I remembered that FreeBSD, OpenBSD, and NetBSD all use the same options as they also use ELF binaries, so I ended up just modifying gcc.lua. Plus this way, it doesn't break any existing tundra.lua configurations which have their "linux-gcc", "freebsd-gcc", or "openbsd-gcc" Configs set to use the "gcc" tool.

Note that it is still up to the Tundra user to add either "-fpic" or "-fPIC" to their CCOPTS/CXXOPTS, for compiling source files prior to being linked into the target shared library, which I think is the same behavior as with the gcc-osx toolset. If they fail to do so, GCC will just spit out an error message at link-time reminding them to recompile the source files with "-fpic/-fPIC".
