### PR TITLE
Fix "osx-bundle" example (missing tundra.syntax.)

### DIFF
--- a/examples/osx-bundle/tundra.lua
+++ b/examples/osx-bundle/tundra.lua
@@ -8,7 +8,7 @@ Build {
 		},
 	},
 
-	SyntaxExtensions = { "osx-bundle" },
+	SyntaxExtensions = { "tundra.syntax.osx-bundle" },
 
 	Units = "units.lua",
 }


### PR DESCRIPTION
Fix "osx-bundle" example following "use explicit package names" for syntax modules
Commit id: d9ad231f27be72db6796bdcc1f2da69cb55055d2
