### PR TITLE
Patch for issue #110

### DIFF
--- a/src/ancestors.c
+++ b/src/ancestors.c
@@ -79,7 +79,8 @@ td_load_ancestors(td_engine *engine)
 	file_size = ftell(f);
 	rewind(f);
 
-	fread(&magic, 1, sizeof magic, f);
+	if (fread(&magic, 1, sizeof magic, f)) {
+	}
 	if (magic != TD_ANCESTOR_MAGIC) {
 		fprintf(stderr, "warning: bad ancestor magic; discarding build history\n");
 		fclose(f);

--- a/src/portable.c
+++ b/src/portable.c
@@ -790,7 +790,7 @@ td_get_executable_path(char *buffer, size_t bufsize)
 const char *
 td_init_homedir(void)
 {
-	char dir[512];
+	char dir[PATH_MAX > 512 ? PATH_MAX : 512];
 	char* tmp;
 
 	if (NULL != (tmp = getenv("TUNDRA_HOME")))
@@ -805,7 +805,7 @@ td_init_homedir(void)
 	return set_homedir(dir);
 #else
 	{
-		char resolved[512];
+		char resolved[PATH_MAX > 512 ? PATH_MAX : 512];
 		if ((tmp = dirname(realpath(dir, resolved))))
 			return set_homedir(tmp);
 		else

--- a/src/tty.c
+++ b/src/tty.c
@@ -214,7 +214,8 @@ flush_output_queue(int job_id)
 	for (i = 0; i < count; ++i)
 	{
 		line_buffer *b = buffers[i];
-		write(b->is_stderr ? STDERR_FILENO : STDOUT_FILENO, b->data, strlen(b->data));
+		if (write(b->is_stderr ? STDERR_FILENO : STDOUT_FILENO, b->data, strlen(b->data))) {
+		}
 	}
 
 	/* Compact the queue, removing the buffers from this job. */
@@ -311,7 +312,8 @@ tty_emit(int job_id, int is_stderr, int sort_key, const char *data, int len)
 			TTY_PRINTF(("copying %d bytes of data from job_id %d, stderr=%d, sort_key %d\n",
 						len, job_id, is_stderr, sort_key));
 
-			write(is_stderr ? STDERR_FILENO : STDOUT_FILENO, data, strlen(data));
+			if (write(is_stderr ? STDERR_FILENO : STDOUT_FILENO, data, strlen(data))) {
+			}
 			return; /* finish the loop immediately */
 		}
 		else


### PR DESCRIPTION
In the headers on Ubuntu 11.10, there are annotations that cause a
warning when the return value of write and fread are unchecked by
application code.

There is a similar warning about passing in a path shorter than PATH_MAX
to the realpath function.

These problems are addressed by wrapping the write and fread calls in
empty if statements, and by enlarging the buffer used for the path.
