### PR TITLE
Modify C/++ #include scanner to add an implicit newline at file end.

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -132,7 +132,7 @@ scan_file_data(td_alloc *scratch, td_file *file, td_include_data *out, int max_c
 	if (NULL == (f = fopen(file->path, "r")))
 		return 0;
 
-	for (; !at_end_of_file ;)
+	for (; !at_end_of_file && buffer_size != 0 ;)
 	{
 		char *p, *line;
 		int count, remain;


### PR DESCRIPTION
This behaviour is C++11 conformant, and it is the path of least
surprise.
