### PR TITLE
Patch for Issue #110

### DIFF
--- a/src/ancestors.c
+++ b/src/ancestors.c
@@ -79,8 +79,8 @@ td_load_ancestors(td_engine *engine)
 	file_size = ftell(f);
 	rewind(f);
 
-	fread(&magic, 1, sizeof magic, f);
-	if (magic != TD_ANCESTOR_MAGIC) {
+	read_count = fread(&magic, 1, sizeof magic, f);
+	if (read_count != 1 || magic != TD_ANCESTOR_MAGIC) {
 		fprintf(stderr, "warning: bad ancestor magic; discarding build history\n");
 		fclose(f);
 		return;

--- a/src/portable.c
+++ b/src/portable.c
@@ -790,7 +790,7 @@ td_get_executable_path(char *buffer, size_t bufsize)
 const char *
 td_init_homedir(void)
 {
-	char dir[512];
+	char dir[PATH_MAX];
 	char* tmp;
 
 	if (NULL != (tmp = getenv("TUNDRA_HOME")))
@@ -805,7 +805,7 @@ td_init_homedir(void)
 	return set_homedir(dir);
 #else
 	{
-		char resolved[512];
+		char resolved[PATH_MAX];
 		if ((tmp = dirname(realpath(dir, resolved))))
 			return set_homedir(tmp);
 		else


### PR DESCRIPTION
This fixes the warnings on Ubuntu 11.10 introduced by gcc 4.6 or annotation changes to the glibc headers (I'm not sure which). I believe this addresses the suggestions you gave on Zao's pull request; that one has been idle for a few months so I assume he abandoned it.
