### PR TITLE
Changed the docs to the working FGlob ignore trick

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -782,7 +782,7 @@ Program {
             Filters = {
                 { Pattern = "/debug/"; Config = "*-*-debug" },
                 { Pattern = "win32"; Config = "win32-*-*" },
-                { Pattern = "_[^/]*$"; Config = "ignore" },
+                { Pattern = "/_[^/]*$"; Config = "ignore" },
             }
         }
     },
@@ -791,8 +791,11 @@ Program {
 -------------------------------------------------------------------------------
 
 If you wish to exclude files based on a pattern you can specify a configuration
-that doesn't exist. In the above example the pattern `_[^/]*$` will ignore all 
+that doesn't exist. In the above example the pattern `/_[^/]*$` will ignore all 
 files where the file name starts with `_`.
+
+The initial forward slash is necessary as tundra passes the full path before 
+applying the filter.
 
 Lua patterns are not regular expressions but they are closely related. Instead 
 of using backslash, `%` is used to reference predefined character classes or 


### PR DESCRIPTION
I noticed that since the paths are passed as full paths the pattern matching lua stuff got confused. The fix for that was to simply include a forward slash in the beginning to anchor the match as a file name given the presence of the `$`.
