### PR TITLE
Some fixes for msvc project generation

### DIFF
--- a/scripts/tundra/ide/msvc100.lua
+++ b/scripts/tundra/ide/msvc100.lua
@@ -238,14 +238,21 @@ function msvc_generator:generate_files(ngen, config_tuples, raw_nodes, env)
 			projects[#projects + 1] = data
 		end
 	end
+	
+	local source_list = { "tundra.lua" }
+	local units = io.open("units.lua")
+	if units then
+		source_list[#source_list + 1] = "units.lua"
+		io.close(units)
+	end
 
 	local meta_name = "00-Tundra"
 	projects[#projects + 1] = {
-		Decl = { Name = meta_name, },
+		Decl = { Name = meta_name, Sources = source_list },
 		Type = "meta",
 		RelativeFilename = meta_name .. ".vcxproj",
 		Filename = env:interpolate("$(OBJECTROOT)$(SEP)" .. meta_name .. ".vcxproj"),
-		Sources = { "tundra.lua" },
+		Sources = { "tundra.lua" }, 
 		Guid = native.digest_guid(meta_name),
 		IsMeta = true,
 	}


### PR DESCRIPTION
Three fixes for the msvc project generation:
1. Use --full-paths when compiling as otherwise msvc (for the most time) isn't able to pick up the correct path of the files so you wont able to jump directly to the file/line of an error.
2. Some files weren't included in the generated solution (esp those within filters)
3. If units.lua is present on disk then include it in the 00-Tundra project
