### PR TITLE
Added GNU Assembler toolset support and fixed build problem on Debian 6.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ endif (WIN32)
 
 if (UNIX)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Werror")
+    
+	# Required for earlier versions of glibc to enable POSIX.1-2008 interfaces.
+	add_definitions(-D_GNU_SOURCE)
 endif (UNIX)
 
 add_executable(gen_lua_data src/gen_lua_data.c)

--- a/scripts/tundra/tools/gas.lua
+++ b/scripts/tundra/tools/gas.lua
@@ -1,0 +1,29 @@
+-- Copyright 2011 Andreas Fredriksson
+--
+-- This file is part of Tundra.
+--
+-- Tundra is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- Tundra is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with Tundra.  If not, see <http://www.gnu.org/licenses/>.
+
+module(..., package.seeall)
+
+function apply(env, options)
+	-- load the generic assembly toolset first
+	tundra.boot.load_toolset("generic-asm", env)
+
+	env:set_many {
+		["ASM"] = "as",
+		["ASMCOM"] = "$(ASM) -o $(@) $(ASMDEFS:p-D) $(ASMOPTS) $(<)",
+		["ASMINC_KEYWORDS"] = { ".include" },
+	}
+end

--- a/tundra.lua
+++ b/tundra.lua
@@ -32,9 +32,10 @@ local common = {
 			{ "/Ox"; Config = "*-msvc-release" },
 		},
 		CPPDEFS = {
-			{ "_CRT_SECURE_NO_WARNINGS"; Config = "*-msvc-*"  },
-			{ "NDEBUG"; Config = "*-*-release"  },
-			{ "TD_STANDALONE"; Config = "*-*-*-standalone"  },
+			{ "_CRT_SECURE_NO_WARNINGS"; Config = "*-msvc-*" },
+			{ "_GNU_SOURCE"; Config = "linux-*" },
+			{ "NDEBUG"; Config = "*-*-release" },
+			{ "TD_STANDALONE"; Config = "*-*-*-standalone" },
 		},
 	}
 }


### PR DESCRIPTION
Hey, I needed to be able to use the GNU Assembler from within tundra for one of my projects, so I just copied your existing YASM toolset implementation in yasm.lua, and modified it for the GNU Assembler, creating scripts/tundra/tools/gas.lua. Thought it would be a good idea to make this available.

I also ran into a problem trying to get tundra to build on distributions with older versions of glibc/eglibc, which don't make available the POSIX.1-2008 interfaces by default. So the build would fail out when it tried to use a few of the more recently standardized pthread features like PTHREAD_MUTEX_RECURSIVE. The work around is to make sure _GNU_SOURCE preprocessor definition is defined during compilation, so I simply updated both CMakeLists.txt and tundra.lua to do just that. It doesn't cause any forward compatibility problems with newer glibc/eglibc versions.

This allowed me to be able to build tundra on a vanilla Debian 6.0 installation without trouble.
