### PR TITLE
aux outputs: lookup by node keyword rather than node label

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -1019,7 +1019,7 @@ These environment variables apply to C-based toolsets:
 - `SHLIBOPTS` - Options specific to creating a shared library
 - `SHLIBCOM` - Command line to create a shared library
 - `FRAMEWORKS` - (OS X) Frameworks to include and link with
-- `AUX_FILES_PROGRAM`, `AUX_FILES_SHAREDLIB` - List of patterns that expand to auxilliary files to clean for programs, shared libraries. Useful to clean up debug and map files.
+- `AUX_FILES_PROGRAM`, `AUX_FILES_SHAREDLIBRARY` - List of patterns that expand to auxilliary files to clean for programs, shared libraries. Useful to clean up debug and map files.
 
 These environment variables apply to .NET-based toolsets:
 

--- a/scripts/tundra/syntax/native.lua
+++ b/scripts/tundra/syntax/native.lua
@@ -29,7 +29,7 @@ local _native_mt = nodegen.create_eval_subclass {
 		Frameworks = "FRAMEWORKS",
 		LibPaths = "LIBPATH",
 	},
-} 
+}
 
 local _object_mt = nodegen.create_eval_subclass({
 	Suffix = "$(OBJECTSUFFIX)",
@@ -165,14 +165,14 @@ function _native_mt:create_dag(env, data, input_deps)
 		end
 	end
 
-	local aux_outputs = env:get_list("AUX_FILES_" .. self.Label:upper(), {})
+	local aux_outputs = env:get_list("AUX_FILES_" .. self.Keyword:upper(), {})
 
 	if env:get('GENERATE_PDB', '0') ~= '0' then
 		aux_outputs[#aux_outputs + 1] = "$(_PDB_FILE)"
 	end
 
 	local extra_inputs = {}
-	
+
 	if env:has_key('MODDEF') then
 		extra_inputs[#extra_inputs + 1] = "$(MODDEF)"
 	end

--- a/scripts/tundra/tools/msvc.lua
+++ b/scripts/tundra/tools/msvc.lua
@@ -62,6 +62,6 @@ function apply(env, options)
 		["SHLIBOPTS"] = "",
 		["SHLIBCOM"] = "$(LD) /DLL /nologo @RESPONSE|@|$(_USE_PDB_LINK) $(SHLIBOPTS) $(LIBPATH:b:p/LIBPATH\\:) $(_USE_MODDEF) $(LIBS) /out:$(@:b) $(<:b)",
 		["AUX_FILES_PROGRAM"] = { "$(@:B:a.exe.manifest)", "$(@:B:a.pdb)" },
-		["AUX_FILES_SHAREDLIB"] = { "$(@:B:a.dll.manifest)", "$(@:B:a.pdb)", "$(@:B:a.exp)", "$(@:B:a.lib)", },
+		["AUX_FILES_SHAREDLIBRARY"] = { "$(@:B:a.dll.manifest)", "$(@:B:a.pdb)", "$(@:B:a.exp)", "$(@:B:a.lib)", },
 	}
 end


### PR DESCRIPTION
Program's label is Program $(@) which meant we looked up the AUX_FILES_
environment variables incorrectly.

By switching to self.Keyword we lookup AUX_FILES_PROGRAM and correctly
detect the output files. Which are thus correctly cleaned up.

AUX_FILES_SHAREDLIB is renamed to AUX_FILES_SHAREDLIBRARY [API Change]
