### PR TITLE
Add support for underscore characters in Config names

### DIFF
--- a/scripts/tundra/boot.lua
+++ b/scripts/tundra/boot.lua
@@ -629,7 +629,7 @@ function _G.Config(args)
 	if not name then
 		error("no `Name' specified for configuration")
 	end
-	if not name:match("^%w+-%w+$") then
+	if not name:match("^[%w_]+-[%w_]+$") then
 		errorf("configuration name %s doesn't follow <platform>-<toolset> pattern", name)
 	end
 

--- a/scripts/tundra/nodegen.lua
+++ b/scripts/tundra/nodegen.lua
@@ -384,8 +384,8 @@ local pattern_cache = {}
 local function get_cached_pattern(p)
 	local v = pattern_cache[p]
 	if not v then
-		local comp = '%w+'
-		local sub_pattern = p:gsub('*', '%%w+')
+		local comp = '[%w_]+'
+		local sub_pattern = p:gsub('*', '[%%w_]+')
 		local platform, tool, variant, subvariant = boot.match_build_id(sub_pattern, comp)
 		v = string.format('^%s%%-%s%%-%s%%-%s$', platform, tool, variant, subvariant)
 		pattern_cache[p] = v


### PR DESCRIPTION
This patch allows use of underscores in Config platform, toolset,
variant, and subvariant names. This is primarily useful for the
platform names when needing to support a wide variety of cross-
compilation targets or for autoconf integration, but it can't
hurt for toolset, variant, or subvariant names. It makes it easier
to simply convert a canonical autoconf host/target triplet from
hyphen to underscore form and use it as the platform identifier.

For example, in your tundra.lua:

Configs = {
    Config { Name = "arm_linux_gnu-gcc", ... },
    Config { Name = "i686_linux_gnu-gcc", ... },
    Config { Name = "x86_64_linux_gnu-gcc", ... },
    Config { Name = "powerpc_linux_gnu-gcc", ... },
    Config { Name = "powerpc64_linux_gnu-gcc", ... },
    Config { Name = "i686_linux_gnu-clang", ... },
    Config { Name = "x86_64_linux_gnu-clang", ... },
    Config { Name = "arm_linux_uclibc-gcc", ... },
    Config { Name = "i686_linux_uclibc-gcc", ... },
    Config { Name = "x86_64_linux_uclibc-gcc", ... },
    Config { Name = "arm_linux_androideabi-gcc", ... },
    ...
}
