### PR TITLE
I found a missing trailing backslash.

### DIFF
--- a/scripts/tundra/tools/msvc-winsdk.lua
+++ b/scripts/tundra/tools/msvc-winsdk.lua
@@ -48,7 +48,7 @@ local compiler_dirs = {
 		["x86"] = "bin\\",
 		["x64"] = {
 			["11.0"] = "bin\\x86_amd64\\",
-			"bin\\amd64"
+			"bin\\amd64\\"
 		},
 		["itanium"] = "bin\\x86_ia64\\",
 	},


### PR DESCRIPTION
Building with winsdk7 did't work  but winsdk8 did, I presume this is why.

**NOTE: this is the last time I ask anyone to pull from master... I'm still learning git and DVCS... putting it mildly, it's not a good idea to do what I'm doing, so if you wish to reject this pull request, I won't feel bad about it.**
