### PR TITLE
Fixed issue when tools is just a single table

### DIFF
--- a/scripts/tundra/boot.lua
+++ b/scripts/tundra/boot.lua
@@ -359,7 +359,17 @@ local function setup_env(env, tuple, build_id)
 			end
 
 			if type(data) == "string" then
+				
+				-- if tools options where set like this { "tool" ; Option = "value" }
+				if options == nil then
+					options = {}
+					for k, v in next, tools, next(tools) do -- skip first
+						options[k] = v
+					end
+				end
+
 				load_toolset(data, env, options)
+
 			elseif type(data) == "function" then
 				data(env, options)
 			else


### PR DESCRIPTION
It does look a bit strange, that it has to reference tools, but that's how it's scoped. Interesting little tidbit, `ipairs` ignores named entries in the table. That's why this code didn't already fail with the `error("bad parameters")`, I did not know that.

tundra --init currently yields a file with this, which won't work if the above patch isn't applied.

```
Config {
    Name = "win64-msvc",
    DefaultOnHost = "windows",
    Tools = { "msvc-vs2012"; TargetArch = "x64" }, -- this!
},
```
