### PR TITLE
path fix for MSVC ide support

### DIFF
--- a/scripts/tundra/ide/msvc100.lua
+++ b/scripts/tundra/ide/msvc100.lua
@@ -115,7 +115,7 @@ function msvc_generator:generate_project(project)
 
 		local root_dir = ".." -- FIXME
 		local build_id = string.format("%s-%s-%s", tuple.Config.Name, tuple.Variant.Name, tuple.SubVariant)
-		local base = tundra.boot.TundraExePath .. " --full-paths -C " .. root_dir .. " "
+		local base = "\"" .. tundra.boot.TundraExePath .. "\" --full-paths -C " .. root_dir .. " "
 		build_cmd = base .. build_id
 		clean_cmd = base .. "-c " .. build_id
 

--- a/scripts/tundra/ide/msvc80.lua
+++ b/scripts/tundra/ide/msvc80.lua
@@ -113,7 +113,7 @@ function msvc_generator:generate_project(project)
 		if project.IsMeta then
 			local root_dir = ".." -- FIXME
 			local build_id = string.format("%s-%s-%s", tuple.Config.Name, tuple.Variant.Name, tuple.SubVariant)
-			local base = tundra.boot.TundraExePath .. " -C " .. root_dir .. " "
+			local base = "\"" .. tundra.boot.TundraExePath .. "\" -C " .. root_dir .. " "
 			build_cmd = base .. build_id
 			clean_cmd = base .. "-c " .. build_id
 		end


### PR DESCRIPTION
Quick fix for tundra exe paths with spaces (e.g. C:\Program Files\Tundra\tundra.exe) by adding quotes when generating msvc sln files.
