### PR TITLE
Fixed Clang warning

### DIFF
--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -469,7 +469,7 @@ static bool WriteScanner(BinaryLocator* ptr_out, BinarySegment* seg, BinarySegme
     {
       BinarySegmentAlign(array_seg, 4);
       BinarySegmentWritePointer(seg, BinarySegmentPosition(array_seg));
-      auto write_kws = [array_seg, str_seg](const JsonArrayValue* array, bool follow)
+      auto write_kws = [array_seg, str_seg](const JsonArrayValue* array, bool follow) -> bool
       {
         if (array)
         {


### PR DESCRIPTION
Fixed the following warning:

src/DagGenerator.cpp:472:24: warning: C++11 requires lambda with omitted result type to consist of a single return statement
      [-Wlambda-extensions]
      auto write_kws = [array_seg, str_seg](const JsonArrayValue* array, bool follow)
                                ^  
