### PR TITLE
Added support for lua debugger

### DIFF
--- a/scripts/tundra.lua
+++ b/scripts/tundra.lua
@@ -23,9 +23,19 @@ local function main(action_name, ...)
   assert(action_name, "need an action")
 
   local action = actions[action_name]
-  assert(action, "unknown action")
+    assert(action, "unknown action '" .. action_name .. "'")
 
-  action(...)
+  -- check if debugger was requested
+  for i, v in ipairs(arg) do
+    if v == "--lua-debugger" then
+      table.remove(arg, i)
+      require "tundra.debugger"
+      pause()
+      break
+    end
+  end
+
+  action(unpack(arg))
 end
 
 return {


### PR DESCRIPTION
Added the ability to invoke the lua debugger at startup, I find it useful when debugging my custom tool chain and code gen actions.

I also expandeded a little bit on the error message, if you invoke --lua-debugger instead of action first, you get error `unknown action '--lua-debugger'` instead of just `unknown action`

I made it so that the action name still has to be first, but the --lua-debugger part can occur anywhere after the action and won't be forwarded to the actions, so it will not integer with their command line processing.
