### PR TITLE
Force MSPDBSRV.EXE when using Visual Studio 2013

### DIFF
--- a/scripts/tundra/tools/msvc-vscommon.lua
+++ b/scripts/tundra/tools/msvc-vscommon.lua
@@ -211,6 +211,12 @@ function apply_msvc_visual_studio(version, env, options)
     env:set("RCOPTS", "") -- clear the "/nologo" option (it was first added in VS2010)
   end
  
+  if version == "12.0" then
+    -- Force MSPDBSRV.EXE
+    env:set("CCOPTS", "/FS")
+    env:set("CXXOPTS", "/FS")
+  end
+ 
   -- Wire-up the external environment
 
   env:set_external_env_var('VSINSTALLDIR', vs_root)


### PR DESCRIPTION
Actually, we have to make one more change which, I forgot to include in the pull request and that's to forcefully use MSPDBSRV when using the VS2013 compiler.
