### PR TITLE
Add IdeGenerationHints.BuildAllByDefault for MSVC

### DIFF
--- a/examples/fancyvs/tundra.lua
+++ b/examples/fancyvs/tundra.lua
@@ -81,5 +81,12 @@ Build {
       ['ProgramOnly.sln'] = { Projects = { "prog" } },
       ['LibOnly.sln'] = { Projects = { "blahlib" } },
     },
+
+    -- Cause all projects to have "Build" ticked on them inside the MSVC Configuration Manager.
+    -- As a result of this, you can choose a project as the "Startup Project",
+    -- and when hitting "Debug" or "Run", the IDE will build that project before running it.
+    -- You will want to avoid pressing "Build Solution" with this option turned on, because MSVC
+    -- will kick off all project builds simultaneously.
+    BuildAllByDefault = true,
   }
 }

--- a/scripts/tundra/ide/msvc-common.lua
+++ b/scripts/tundra/ide/msvc-common.lua
@@ -168,6 +168,7 @@ local function make_project_data(units_raw, env, proj_extension, hints, ide_scri
         RelativeFilename = relative_fn,
         Filename         = base_dir .. relative_fn,
         Guid             = get_guid_string(name),
+        BuildByDefault   = hints.BuildAllByDefault,
       }
     end
     return project_by_name[name]


### PR DESCRIPTION
This option causes all projects to have "Build" ticked on them
inside the MSVC Configuration Manager.
As a result of this, you can choose a project as the "Startup Project",
and when hitting "Debug" or "Run", the IDE will build that project
before running it.
You will want to avoid pressing "Build Solution" with this option
turned on, because MSVC will kick off all project builds simultaneously.
