### PR TITLE
added unformatted TerminalIoPrint

### DIFF
--- a/src/TerminalIo.cpp
+++ b/src/TerminalIo.cpp
@@ -352,14 +352,19 @@ void TerminalIoJobExit(int job_id)
 	CondBroadcast(&s_CanPrint);
 }
 
+void TerminalIoPrint(int job_id, int sort_key, const char *data)
+{
+	TerminalIoEmit(job_id, 0, sort_key, data, (int) strlen(data));
+}
+
 void TerminalIoPrintf(int job_id, int sort_key, const char *format, ...)
 {
 	char buffer[2048];
 	va_list a;
 	va_start(a, format);
-	vsnprintf(buffer, sizeof(buffer), format, a);
-	buffer[sizeof(buffer)-1] = '\0';
-	TerminalIoEmit(job_id, 0, sort_key, buffer, (int) strlen(buffer));
+	int	n = vsnprintf(buffer, sizeof(buffer), format, a);
+	if (n > 0)
+		TerminalIoEmit(job_id, 0, sort_key, buffer, n);
 	va_end(a);
 }
 

--- a/src/TerminalIo.hpp
+++ b/src/TerminalIo.hpp
@@ -9,6 +9,7 @@ void TerminalIoDestroy(void);
 
 void TerminalIoEmit(int job_id, int is_stderr, int sort_key, const char *data, int len);
 void TerminalIoJobExit(int job_id);
+void TerminalIoPrint(int job_id, int sort_key, const char *data);
 void TerminalIoPrintf(int job_id, int sort_key, const char *format, ...);
 
 }


### PR DESCRIPTION
TerminalIoPrintf's buffer wasn't big enough for some command lines.  Rather than increase it I added an unformatted version to pass the buffer string directly.
