### PR TITLE
Added DOTNET_SUFFIXES(_RESOURCE) to dotnet.lua

### DIFF
--- a/scripts/tundra/tools/dotnet.lua
+++ b/scripts/tundra/tools/dotnet.lua
@@ -15,6 +15,8 @@ function apply(env, options)
 
   -- C# support
   env:set_many {
+    ["DOTNET_SUFFIXES"] = { ".cs" },
+    ["DOTNET_SUFFIXES_RESOURCE"] = { ".resource" },
     ["CSC"] = "csc.exe",
     ["CSPROGSUFFIX"] = ".exe",
     ["CSLIBSUFFIX"] = ".dll",


### PR DESCRIPTION
C# builds with the dotnet toolset would fail without these two environment settings (which I copied from the Mono toolset).
