### PR TITLE
Fixed bug with nested groups in Xcode 5 IDE generator.

### DIFF
--- a/scripts/tundra/ide/xcode5.lua
+++ b/scripts/tundra/ide/xcode5.lua
@@ -522,7 +522,7 @@ local function make_groups(p, files, key)
     local path, filename = split(entry.Value)
 	for i, part in ipairs(split_str(path, "/")) do
       if part ~= '.' then
-        local grp = group.Children[part]
+        local grp = parent_group.Children[part]
         if grp == nil then
 		  grp = { Type = 1, Key=newid(util.tostring(parent_group)..part), Children={} }
           parent_group.Children[part] = grp


### PR DESCRIPTION
The current Xcode 5 IDE generator had an issue with nested folders of source files. Looks like it was just a bit of a typo.
