### PR TITLE
Add support for MSVC IDE variant mappings that include subvariants

### DIFF
--- a/scripts/tundra/ide/msvc-common.lua
+++ b/scripts/tundra/ide/msvc-common.lua
@@ -798,6 +798,8 @@ function msvc_generator:generate_files(ngen, config_tuples, raw_nodes, env, defa
       tuple.MsvcPlatform = assert(m.Platform)
     elseif variant_mappings[tuple.Variant.Name] then
       tuple.MsvcConfiguration = variant_mappings[tuple.Variant.Name]
+    elseif variant_mappings[tuple.Variant.Name .. "-" .. tuple.SubVariant] then
+      tuple.MsvcConfiguration = variant_mappings[tuple.Variant.Name .. "-" .. tuple.SubVariant]
     else
       tuple.MsvcConfiguration = tuple.Variant.Name
     end


### PR DESCRIPTION
For example, in your MSVC generation hints, you can now write:
VariantMappings = {
  ['release-default']    = 'Release'
  ['release-analyze']    = 'Release-Analyze',
}
...and you'll get a Release and Release-Analyze configuration in your IDE.

One could already achieve this with the FullMapping hint, but that forces
one to enumerate all build configurations, which is tedious when the
number of configurations is high.
