### PR TITLE
Added optional TUNDRA_LUA_PATH so that tundra can include additional script files from a user defined directory

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -553,8 +553,9 @@ lua_State* CreateLuaState(MemAllocHeap* lua_heap, bool profile)
   // setup package.path
   {
     const char* homedir = FindScriptDirectory();
+    const char* luapath = getenv("TUNDRA_LUA_PATH");
     char ppath[1024];
-    snprintf(ppath, sizeof(ppath), "%s" TD_PATHSEP_STR "?.lua;", homedir);
+    snprintf(ppath, sizeof(ppath), "%s" TD_PATHSEP_STR "?.lua;%s", homedir, (luapath ? luapath : ""));
     lua_getglobal(L, "package");
     CHECK(LUA_TTABLE == lua_type(L, -1));
 


### PR DESCRIPTION
Tested on Windows + Linux
The path should separate paths with semicolon as described in http://www.lua.org/pil/8.1.html

Usage:
Create a file ~/tundrascripts/foo.lua
Set the environment variable: export TUNDRA_LUA_PATH=~/tundrascripts/?.lua
Now foo.lua can be included in any tundra script with a: local foo = require('foo')
