### PR TITLE
set where OSX frameworks are with FRAMEWORKPATH

### DIFF
--- a/scripts/tundra/tools/gcc-osx.lua
+++ b/scripts/tundra/tools/gcc-osx.lua
@@ -8,11 +8,13 @@ function apply(env, options)
     ["NATIVE_SUFFIXES"] = { ".c", ".cpp", ".cc", ".cxx", ".m", ".mm", ".a", ".o" },
     ["CXXEXTS"] = { "cpp", "cxx", "cc", "mm" },
     ["FRAMEWORKS"] = "",
+    ["FRAMEWORKPATH"] = {},
     ["SHLIBPREFIX"] = "lib",
     ["SHLIBOPTS"] = "-shared",
-    ["_OS_CCOPTS"] = "$(FRAMEWORKS:p-F)",
-    ["SHLIBCOM"] = "$(LD) $(SHLIBOPTS) $(LIBPATH:p-L) $(LIBS:p-l) $(FRAMEWORKS:p-framework ) -o $(@) $(<)",
-    ["PROGCOM"] = "$(LD) $(PROGOPTS) $(LIBPATH:p-L) $(LIBS:p-l)  $(FRAMEWORKS:p-framework ) -o $(@) $(<)",
+    ["_OS_CCOPTS"] = "$(FRAMEWORKPATH:p-F)",
+    ["_OS_CXXOPTS"] = "$(FRAMEWORKPATH:p-F)",
+    ["SHLIBCOM"] = "$(LD) $(SHLIBOPTS) $(LIBPATH:p-L) $(LIBS:p-l) $(FRAMEWORKPATH:p-F) $(FRAMEWORKS:p-framework ) -o $(@) $(<)",
+    ["PROGCOM"] = "$(LD) $(PROGOPTS) $(LIBPATH:p-L) $(LIBS:p-l) $(FRAMEWORKPATH:p-F)  $(FRAMEWORKS:p-framework ) -o $(@) $(<)",
     ["OBJCCOM"] = "$(CCCOM)", -- objc uses same commandline
     ["NIBCC"] = "ibtool --output-format binary1 --compile $(@) $(<)",
   }


### PR DESCRIPTION
this allows setting an alternative path for frameworks, such as
libraries installed outside the system paths. For instance QT installed
via hombrew.
