### PR TITLE
add validation for when the command buffer before the response file gets truncated

### DIFF
--- a/src/ExecWin32.cpp
+++ b/src/ExecWin32.cpp
@@ -501,7 +501,18 @@ ExecResult ExecuteProcess(
       }
 
       {
-        int copy_len = std::min((int) (response - cmd_line), (int) (sizeof(command_buf) - 1));
+        const int pre_suffix_len = (int)(response - cmd_line);
+        int copy_len = std::min(pre_suffix_len, (int) (sizeof(command_buf) - 1));
+        if (copy_len != pre_suffix_len)
+        {
+            char truncated_cmd[sizeof(command_buf)];
+            _snprintf(truncated_cmd, sizeof(truncated_cmd) - 1, "%s", cmd_line);
+            truncated_cmd[sizeof(truncated_cmd)-1] = '\0';
+
+            fprintf(stderr, "Couldn't copy command (%s...) before response file suffix. "
+                "Move the response file suffix closer to the command starting position.\n", truncated_cmd);
+            return result;
+        }
         strncpy(command_buf, cmd_line, copy_len);
         command_buf[copy_len] = '\0';
         copy_len = std::min((int) (option_end - option), (int) (sizeof(option_buf) - 1));


### PR DESCRIPTION
Same change, new PR...

> While playing with a new toolchain I noticed that my command line got truncated. Finally I found out that it was the command before the respone file suffix that was too big for the current command_buf length.
> 
> I added a validation for it along what should be a clear message of what's happening and what to do about it and I stop the execution instead of letting it continue with a truncated command that won't probably work as expected (if at all).
