### PR TITLE
Added default Lua path relative current working directory

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -555,7 +555,7 @@ lua_State* CreateLuaState(MemAllocHeap* lua_heap, bool profile)
     const char* homedir = FindScriptDirectory();
     const char* luapath = getenv("TUNDRA_LUA_PATH");
     char ppath[1024];
-    snprintf(ppath, sizeof(ppath), "%s" TD_PATHSEP_STR "?.lua;%s", homedir, (luapath ? luapath : ""));
+    snprintf(ppath, sizeof(ppath), "%s" TD_PATHSEP_STR "?.lua;." TD_PATHSEP_STR "?.lua;%s", homedir, (luapath ? luapath : ""));
     lua_getglobal(L, "package");
     CHECK(LUA_TTABLE == lua_type(L, -1));
 


### PR DESCRIPTION
I'm proposing a minor change to the default Lua path. Note that, this is an entirely unnecessary code change since the `TUNDRA_LUA_PATH` environment variable can accomplish the same thing and more. 

I do think that the behavior outlined below is warranted but I won't feel bad if we settle for a simple documentation change (cuz that's what it boils down to really).

This all originated with the need for a custom tool chain. I started out with a very specific GCC toolchain, like this:

    module(..., package.seeall)
    function apply(env, options)
      tundra.unitgen.load_toolset("gcc", env)
      env:set_many {
        ["CC"] = "/opt/gcc-4.8.1/bin/gcc",
        ["CXX"] = "/opt/gcc-4.8.1/bin/g++",
        ["CXXOPTS"] = "-std=c++11",
        ["LD"] = "/opt/gcc-4.8.1/bin/g++",
        ["PROGOPTS"] = "-static",
      }
    end

I call this script `gcc481.lua` and place it in a folder called `./tundra/tools` (relative my project root). We get the following Lua error:

    /usr/local/share/tundra/tundra/unitgen.lua:34: module 'tundra.tools.gcc481' not found:
        no field package.preload['tundra.tools.gcc481']
        no file '/usr/local/share/tundra/tundra/tools/gcc481.lua'
        no file './tundra/tools/gcc481.so'
        no file '/usr/local/lib/lua/5.1/tundra/tools/gcc481.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'
        no file './tundra.so'
        no file '/usr/local/lib/lua/5.1/tundra.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'

We can of course install the new tool chain to `/usr/local/share` but it requires both root access and additional configuration. I much rather have my project contain the tool chain script and version control this from within my repo. To do that, I want it to pick up paths relative the current directory.

With this change the search order becomes:

        no file '/usr/local/share/tundra/tundra/tools/gcc481.lua'
        no file './tundra/tools/gcc481.lua'
        no file './tundra/tools/gcc481.so'
        no file '/usr/local/lib/lua/5.1/tundra/tools/gcc481.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'
        no file './tundra.so'
        no file '/usr/local/lib/lua/5.1/tundra.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'

What I find interesting is that it will look for a `.so` file relative the current directory but not a `.lua` file. (This got me turned around a bit at first.). With that in mind, it does seem more consistent this way. It will also you to override (swap) any Tundra Lua script during development of Tundra itself (or testing for that matter).

While great, `TUNDRA_LUA_PATH` is undocumented and non-standard. I get why it is that way but one of the first things I tried was to set `LUA_PATH` per the Lua documentation. That did nothing of course and I eventually figured out that it was `TUNDRA_LUA_PATH` I had to modify by examining the loader code. I believe there used to be a `ScriptDirs` configuration parameter but I guess `TUNDRA_LUA_PATH` replaces this functionality. (I'll update the docs if this is the case).

It's silly really because you can just as easily opt-in to by modifying the environment in a simple shell build script (and invoke Tundra through that) but if we commit something like this you won't be able to opt-out. 

Please advice.