### PR TITLE
Fix for Makefile when using Tundra as a submodule.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ LDFLAGS ?= -L$(BUILDDIR) -ltundra
 
 PREFIX ?= /usr/local
 
-GIT_BRANCH := $(shell git branch 2>/dev/null | sed -n '/^\*/s/^\* //p')
+GIT_CMD = git branch 2>/dev/null | sed -n '/^\*/s/^\* //p' | sed 's/ /_/g' | sed 's/[)(]//g'
+GIT_BRANCH := $(shell $(GIT_CMD) )
 GIT_HEAD := $(shell git rev-parse HEAD 2>/dev/null)
 
 CHECKED ?= no
@@ -148,8 +149,8 @@ all: $(BUILDDIR)/tundra2$(EXESUFFIX) \
 		 $(BUILDDIR)/t2-inspect$(EXESUFFIX) \
 		 $(BUILDDIR)/t2-unittest$(EXESUFFIX)
 
-$(BUILDDIR)/git_version_$(GIT_BRANCH).c: .git/refs/heads/$(GIT_BRANCH)
-	sed 's/^\([A-Fa-f0-9]*\)/const char g_GitVersion[] = "\1";/' < $^ > $@ && \
+$(BUILDDIR)/git_version_$(GIT_BRANCH).c:
+	echo 'const char g_GitVersion[] = "'$(GIT_HEAD)'";' > $@ && \
 	echo 'const char g_GitBranch[] ="'$(GIT_BRANCH)'";' >> $@
 
 $(BUILDDIR)/git_version_$(GIT_BRANCH).o: $(BUILDDIR)/git_version_$(GIT_BRANCH).c


### PR DESCRIPTION
I'm using Tundra as a submodule and the Makefile doesn't work out of the box.

Makefile is using some trickery to find the exact name and hash of the current version. I've replaced the trickery with more simple code and some different trickery to support detached heads.