### PR TITLE
Normalizing glob output paths to have forward slashes as separators.

### DIFF
--- a/scripts/tundra/syntax/glob.lua
+++ b/scripts/tundra/syntax/glob.lua
@@ -21,7 +21,7 @@ local function glob(directory, recursive, filter_fn)
 
   for _, path in ipairs(dirwalk.walk(directory, dir_filter)) do
     if filter_fn(path) then
-      result[#result + 1] = path
+      result[#result + 1] = string.gsub(path, "\\", "/")
     end
   end
   return result
@@ -52,7 +52,7 @@ function Glob(args)
   end
   if not args.Extensions then
     croak("no 'Extensions' specified in Glob (Dir is '%s')", args.Dir)
-  end  
+  end
   local extensions = assert(args.Extensions)
   local ext_lookup = util.make_lookup_table(extensions)
   return glob(args.Dir, recursive, function (fn)
@@ -119,4 +119,3 @@ end
 
 decl.add_function("Glob", Glob)
 decl.add_function("FGlob", FGlob)
-


### PR DESCRIPTION
I noticed when building some filters that output of Glob/FGlob we returning paths with backslashes in some cases. The manual mentions that glob should return forward slashes, so maybe this is a regression in 2.0?

Not sure if this is the preferred solution for this problem, or if it should be addressed in the dirwalk code directly, but I thought I'd submit it anyway. :)