### PR TITLE
Support for VS2015 and Win10 SDK

### DIFF
--- a/scripts/tundra/ide/msvc-common.lua
+++ b/scripts/tundra/ide/msvc-common.lua
@@ -473,7 +473,18 @@ function msvc_generator:generate_project(project, all_projects)
   p:write('<?xml version="1.0" encoding="utf-8"?>', LF)
   p:write('<Project')
   p:write(' DefaultTargets="Build"')
-  p:write(' ToolsVersion="4.0"')
+
+  -- This doesn't seem to change any behaviour, but this is the default
+  -- value when creating a makefile project from VS2013 and VS2015
+  -- wizards.
+  if VERSION_YEAR == '2015' then
+    p:write(' ToolsVersion="14.0"')
+  else if VERSION_YEAR == '2013' then
+    p:write(' ToolsVersion="12.0"')
+  else
+    p:write(' ToolsVersion="4.0"')
+  end
+
   p:write(' xmlns="http://schemas.microsoft.com/developer/msbuild/2003"')
   p:write('>', LF)
 
@@ -516,6 +527,8 @@ function msvc_generator:generate_project(project, all_projects)
       p:write('\t\t<PlatformToolset>v110</PlatformToolset>', LF) -- I have no idea what this setting affects
     elseif VERSION_YEAR == '2013' then
       p:write('\t\t<PlatformToolset>v120</PlatformToolset>', LF) -- I have no idea what this setting affects
+    elseif VERSION_YEAR == '2015' then
+      p:write('\t\t<PlatformToolset>v140</PlatformToolset>', LF) -- I have no idea what this setting affects
     end
     p:write('\t</PropertyGroup>', LF)
   end

--- a/scripts/tundra/ide/msvc140.lua
+++ b/scripts/tundra/ide/msvc140.lua
@@ -1,0 +1,7 @@
+-- Microsoft Visual Studio 2013 Solution/Project file generation
+
+module(..., package.seeall)
+
+local msvc_common = require "tundra.ide.msvc-common"
+
+msvc_common.setup("14.00", "2015")

--- a/scripts/tundra/tools/msvc-vs2015.lua
+++ b/scripts/tundra/tools/msvc-vs2015.lua
@@ -1,0 +1,8 @@
+
+module(..., package.seeall)
+
+local vscommon = require "tundra.tools.msvc-vscommon"
+
+function apply(env, options)
+  vscommon.apply_msvc_visual_studio("14.0", env, options)
+end

--- a/scripts/tundra/tools/msvc-vscommon.lua
+++ b/scripts/tundra/tools/msvc-vscommon.lua
@@ -84,18 +84,37 @@ local post_win8_sdk = {
   },
 }
 
+
+-- Maps from VS version to default SDK version. Also used to imitate behaviour
+-- before this patch, where SDK version was identified by VS version.
+
+local vs_sdk_map = {
+  ["9.0"] = "v6.0A",
+  ["10.0"] = "v7.0A",
+  ["10.1"] = "v7.1A",
+  ["11.0"] = "v8.0",
+  ["12.0"] = "v8.1",
+  -- The current visual studio 2015 download does not include the full windows
+  -- 10 SDK, and new Win32 apps created in VS2015 default to using the 8.1 SDK
+  ["14.0"] = "v8.1" 
+}
+
 -- Each quadruplet specifies a registry key value that gets us the SDK location, 
 -- followed by a folder structure (for each supported target architecture) 
 -- and finally the corresponding bin, include and lib folder's relative location
 
-local sdk_map = { 
-  ["9.0"] = { "SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\v6.0A", "InstallationFolder", pre_win8_sdk_dir, pre_win8_sdk },
-  ["10.0"] = { "SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\v7.0A", "InstallationFolder", pre_win8_sdk_dir, pre_win8_sdk },
-  ["10.1"] = { "SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\v7.1A", "InstallationFolder", pre_win8_sdk_dir, pre_win8_sdk },  
-  ["11.0"] = { "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", "KitsRoot", win8_sdk_dir, post_win8_sdk },
-  ["12.0"] = { "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", "KitsRoot81", win81_sdk_dir, post_win8_sdk },
-  ["14.0"] = { "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", "KitsRoot81", win81_sdk_dir, post_win8_sdk }  -- For now use 8.1 SDK
+local pre_win10_sdk_map = {
+  ["v6.0A"] = { "SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\v6.0A", "InstallationFolder", pre_win8_sdk_dir, pre_win8_sdk },
+  ["v7.0A"] = { "SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\v7.0A", "InstallationFolder", pre_win8_sdk_dir, pre_win8_sdk },
+  ["V7.1A"] = { "SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\v7.1A", "InstallationFolder", pre_win8_sdk_dir, pre_win8_sdk },  
+  ["v8.0"] = { "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", "KitsRoot", win8_sdk_dir, post_win8_sdk },
+  ["v8.1"] = { "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", "KitsRoot81", win81_sdk_dir, post_win8_sdk }
 }
+
+local win10_sdk = {
+  "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", "KitsRoot10"
+}
+
 
 local function get_host_arch()
   local snative = native.getenv("PROCESSOR_ARCHITECTURE")
@@ -126,6 +145,87 @@ function path_it(maybe_list)
   return ipairs({maybe_list})
 end
 
+function get_pre_win10_sdk(sdk_version, vs_version, target_arch)
+  local result = {
+    ["include"] = {},
+  }
+
+  local sdk = pre_win10_sdk_map[sdk_version]
+  assert(sdk, "The requested version of Visual Studio isn't supported")
+
+  local sdk_root = native.reg_query("HKLM", sdk[1], sdk[2])
+  assert(sdk_root, "The requested version of the SDK isn't installed")
+  sdk_root = string.gsub(sdk_root, "\\+$", "\\")
+  
+  local sdk_dir_base = sdk[3]
+
+  local sdk_dir = sdk[4][target_arch]
+  assert(sdk_dir, "The target platform architecture isn't supported by the SDK")
+
+  result.bin = sdk_root .. sdk_dir_base["bin"] .. "\\" .. sdk_dir["bin"]
+
+  local sdk_dir_base_include = sdk_dir_base["include"]
+  for _, v in path_it(sdk_dir["include"]) do
+    result.include[#result.include + 1] = sdk_root .. sdk_dir_base_include .. "\\" .. v
+  end
+
+  result.lib_str = sdk_root .. sdk_dir_base["lib"] .. "\\" .. sdk_dir["lib"]
+  result.root = sdk_root
+
+  -- Windows 10 changed CRT to be split between Windows SDK and VC. It
+  -- appears that when targeting pre-win10 with VS2015 you should always use
+  -- use 10.0.10150.0, according to Microsoft.Cpp.Common.props in MSBuild.
+  if vs_version == "14.0" then
+    local win10_sdk_root = native.reg_query("HKLM", win10_sdk[1], win10_sdk[2])
+    assert(win10_sdk_root, "The windows 10 UCRT is required when building using Visual studio 2015")
+    result.include[#result.include + 1] = win10_sdk_root .. "Include\\10.0.10150.0\\ucrt"
+    result.lib_str = result.lib_str .. ";" .. win10_sdk_root .. "Lib\\10.0.10150.0\\ucrt\\" .. post_win8_sdk[target_arch].lib
+  end
+
+  return result
+end
+
+function get_win10_sdk(sdk_version, vs_version, target_arch)
+  -- Remove v prefix
+  sdk_version = string.sub(sdk_version, 2, -1)
+
+  -- This only checks if the windows 10 SDK specifically is installed. A
+  -- 'dir exists' method would be needed here to check if a specific SDK
+  -- target folder exists.
+  local sdk_root = native.reg_query("HKLM", win10_sdk[1], win10_sdk[2])
+  assert(sdk_root, "The requested version of the SDK isn't installed")
+
+  local result = {
+    ["include"] = {}
+  }
+
+  result.bin = sdk_root .. "bin\\" .. post_win8_sdk[target_arch].bin
+
+  local sdk_dir_base_include = sdk_root .. "include\\" .. sdk_version .. "\\"
+  result.include[#result.include + 1] = sdk_dir_base_include .. "shared"
+  result.include[#result.include + 1] = sdk_dir_base_include .. "ucrt"
+  result.include[#result.include + 1] = sdk_dir_base_include .. "um"
+
+  local sdk_dir_base_lib = sdk_root .. "Lib\\" .. sdk_version .. "\\"
+  result.lib_str = sdk_dir_base_lib .. "ucrt\\" .. post_win8_sdk[target_arch].lib
+  result.lib_str = result.lib_str .. ";" .. sdk_dir_base_lib .. "um\\" .. post_win8_sdk[target_arch].lib
+
+  result.root = sdk_root
+
+  return result
+end
+
+function get_sdk(sdk_version, vs_version, target_arch)
+  -- All versions using v10.0.xxxxx.x use specific releases of the
+  -- Win10 SDK. Other versions are assumed to be pre-win10
+  if string.sub(sdk_version, 1, 6) == "v10.0." then
+    return get_win10_sdk(sdk_version, vs_version, target_arch)
+  else
+    return get_pre_win10_sdk(sdk_version, vs_version, target_arch)
+  end
+end
+
+
 function apply_msvc_visual_studio(version, env, options)
 
   -- NOTE:  don't make changes to  `env` until you've asserted
@@ -146,7 +246,11 @@ function apply_msvc_visual_studio(version, env, options)
 
   local target_arch = options.TargetArch or "x86"
   local host_arch = options.HostArch or get_host_arch()
-  local sdk_version = options.SdkVersion or version -- we identify SDKs by VS version and fallback to current version
+
+  -- SDKs are identified by SdkVersion or vs version
+  -- each VS version defines a default SDK to use.
+  local sdk_version = options.SdkVersion or version 
+  sdk_version = vs_sdk_map[sdk_version] or sdk_version
 
   -- We'll find any edition of VS (including Express) here
   local vs_root = native.reg_query("HKLM", "SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VS7", version)
@@ -167,40 +271,16 @@ function apply_msvc_visual_studio(version, env, options)
   --
   -- Now fix up the SDK
   --
+  local sdk = get_sdk(sdk_version, version, target_arch)  
+
   
-  local sdk_root
-  local sdk_bin
-  local sdk_include = {}
-  local sdk_lib
-  
-  local sdk = sdk_map[sdk_version]
-  assert(sdk, "The requested version of Visual Studio isn't supported")
-
-  sdk_root = native.reg_query("HKLM", sdk[1], sdk[2])
-  assert(sdk_root, "The requested version of the SDK isn't installed")
-  sdk_root = string.gsub(sdk_root, "\\+$", "\\")
-  
-  local sdk_dir_base = sdk[3]
-
-  local sdk_dir = sdk[4][target_arch]
-  assert(sdk_dir, "The target platform architecture isn't supported by the SDK")
-
-  sdk_bin = sdk_root .. sdk_dir_base["bin"] .. "\\" .. sdk_dir["bin"]
-
-  local sdk_dir_base_include = sdk_dir_base["include"]
-  for _, v in path_it(sdk_dir["include"]) do
-    sdk_include[#sdk_include + 1] = sdk_root .. sdk_dir_base_include .. "\\" .. v
-  end
-
-  sdk_lib = sdk_root .. sdk_dir_base["lib"] .. "\\" .. sdk_dir["lib"]
-
   --
   -- Tools
   --
   local cl_exe = '"' .. path_combine(vc_bin, "cl.exe") .. '"'
   local lib_exe = '"' .. path_combine(vc_bin, "lib.exe") .. '"'
   local link_exe = '"' .. path_combine(vc_bin, "link.exe") .. '"'
-  local rc_exe = '"' .. path_combine(sdk_bin, "rc.exe") .. '"' -- pickup the Resource Compiler from the SDK
+  local rc_exe = '"' .. path_combine(sdk.bin, "rc.exe") .. '"' -- pickup the Resource Compiler from the SDK
 
   env:set('CC', cl_exe)
   env:set('CXX', cl_exe)
@@ -226,8 +306,8 @@ function apply_msvc_visual_studio(version, env, options)
 
   local include = {}
 
-  for _, v in ipairs(sdk_include) do
-  include[#include + 1] = v
+  for _, v in ipairs(sdk.include) do
+    include[#include + 1] = v
   end
 
   include[#include + 1] = vs_root .. "VC\\ATLMFC\\INCLUDE"
@@ -238,21 +318,9 @@ function apply_msvc_visual_studio(version, env, options)
   -- the linker will throw an error when looking for libs
   -- Lua does not have a "does directory exist function"
   -- we could use one here
-  local lib_str = sdk_lib .. ";" .. vs_root .. "\\VC\\ATLMFC\\lib\\" .. vc_lib_map[host_arch][target_arch] .. ";" .. vc_lib
+  local lib_str = sdk.lib_str .. ";" .. vs_root .. "\\VC\\ATLMFC\\lib\\" .. vc_lib_map[host_arch][target_arch] .. ";" .. vc_lib
 
-  if version == "14.0" then
-    -- Windows 10 changed CRT to be split between Windows SDK and VC. It
-    -- appears that when targeting 8.1 with VS2015 you should always use
-    -- use 10.0.10150.0, according to Microsoft.Cpp.Common.props in MSBuild.
-    -- This means we need the Windows 10 SDK directory here ever though 
-    -- we might not be targeting Windows 10
-    local win10_sdk_root = native.reg_query("HKLM", "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", "KitsRoot10")
-    assert(win10_sdk_root, "The windows 10 SDK is required when building using Visual studio 2015")
-    include[#include + 1] = win10_sdk_root .. "Include\\10.0.10150.0\\ucrt"
-    lib_str = lib_str .. ";" .. win10_sdk_root .. "Lib\\10.0.10150.0\\ucrt\\" .. post_win8_sdk[host_arch][target_arch]
-  end
-
-  env:set_external_env_var("WindowsSdkDir", sdk_root)
+  env:set_external_env_var("WindowsSdkDir", sdk.root)
   env:set_external_env_var("INCLUDE", table.concat(include, ';'))
 
 
@@ -263,7 +331,7 @@ function apply_msvc_visual_studio(version, env, options)
 
   local path = {}
 
-  path[#path + 1] = sdk_root
+  path[#path + 1] = sdk.root
   path[#path + 1] = vs_root .. "Common7\\IDE"
 
   if "x86" == host_arch then

--- a/scripts/tundra/tools/msvc-vswild.lua
+++ b/scripts/tundra/tools/msvc-vswild.lua
@@ -5,7 +5,7 @@ local vscommon = require "tundra.tools.msvc-vscommon"
 
 function apply(env, options)
 
-  local vsvs = options.VsVersions or { "12.0", "11.0", "10.0", "9.0" }
+  local vsvs = options.VsVersions or { "14.0", "12.0", "11.0", "10.0", "9.0" }
 
   for _, v in ipairs(vsvs) do
   	local v1 = v


### PR DESCRIPTION
This PR adds support for the VS2015 compiler and Windows 10 SDK.

By default the VS2015 targets the windows 8.1 SDK, as that mirrors MSBuild behaviour, but a specific Windows 10 SDK can be targeted by using `SdkVersion` (i.e. `SdkVersion = "v10.0.10166.0"`). To support this I have changed SdkVersion to use the actual SDK version instead of compiler version (i.e. `v7.0A`, `v8.1`). The old `SdkVersion` syntax is still supported and is distinguished by dropping the `v` prefix.