### PR TITLE
This adds Rust support to Tundra

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -778,6 +778,61 @@ are supported:
 }
 -------------------------------------------------------------------------------
 
+=== Rust Units
+
+Tundra has basic support for Rust programs and shared libraries. The following unit types
+are supported:
+
+- `RustProgram` - Builds a Rust executable
+- `RustSharedLibrary` - Builds a Rust library (dll)
+
+.Rust Unit Synopsis
+[source,lua]
+-------------------------------------------------------------------------------
+<unit type> {
+    -- required
+    Name = "...", -- name must match name in Cargo.toml
+    CargoConfig = "...",
+    Sources = { ..., "path/to/project/build.rs" },
+    -- optional
+    Depends = { ... },      -- config filtered
+}
+-------------------------------------------------------------------------------
+
+Tundra will call Cargo to build Rust projects so a Cargo.toml needs to be
+configured (which is the standand way to setup Rust projects) Cargo doesn't support
+command-line args for linking libs so Tundra will set some env variables that
+a Cargo build script that will use to link with the correct libs.
+
+The build.rs will need to look like this (if you use your own the following code
+needs to be added)
+
+.Rust build.rs Synopsis
+[source,lua]
+-------------------------------------------------------------------------------
+use std::env;
+
+fn main() {
+    let tundra_dir = env::var("TUNDRA_OBJECTDIR").unwrap_or("".to_string());
+    let libs = env::var("TUNDRA_STATIC_LIBS").unwrap_or("".to_string());
+
+    let native_libs = libs.split(" ");
+
+    println!("cargo:rustc-link-search=native={}", tundra_dir);
+
+    for lib in native_libs {
+        println!("cargo:rustc-link-lib=static={}", lib);
+        println!("cargo:rerun-if-changed={}", lib);
+    }
+}
+-------------------------------------------------------------------------------
+
+In the examples/rust directory in the Tundra distribution there is examples
+that shows how this is used in practice.
+
+Notice about Windows: Due to a bug that was detected in Cargo when implementing 
+this feature Rust 1.7+ (Beta) is required on Windows.
+
 === Syntax Extensions
 
 Tundra provides a small set of syntax extensions by default. To use syntax

--- a/examples/rust/my_crate/Cargo.lock
+++ b/examples/rust/my_crate/Cargo.lock
@@ -1,0 +1,41 @@
+[root]
+name = "my_crate"
+version = "0.1.0"
+dependencies = [
+ "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "advapi32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/examples/rust/my_crate/Cargo.toml
+++ b/examples/rust/my_crate/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "my_crate"
+version = "0.1.0"
+
+[dependencies]
+rand = "0.3"

--- a/examples/rust/my_crate/src/lib.rs
+++ b/examples/rust/my_crate/src/lib.rs
@@ -1,0 +1,8 @@
+extern crate rand;
+use rand::Rng;
+
+pub fn get_rand() -> u32 {
+    // test
+    let mut t = rand::thread_rng();
+    t.gen::<u32>()
+}

--- a/examples/rust/native_lib/lib.c
+++ b/examples/rust/native_lib/lib.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void print_hello() {
+	printf("hello from C!\n");
+}

--- a/examples/rust/prog/Cargo.lock
+++ b/examples/rust/prog/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "prog"
+version = "0.1.0"
+

--- a/examples/rust/prog/Cargo.toml
+++ b/examples/rust/prog/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "prog"
+version = "0.1.0"
+build = "build.rs"
+
+[dependencies]
+my_crate = { path = "../my_crate" }
+

--- a/examples/rust/prog/build.rs
+++ b/examples/rust/prog/build.rs
@@ -1,0 +1,17 @@
+use std::env;
+
+fn main() {
+    let tundra_dir = env::var("TUNDRA_OBJECTDIR").unwrap_or("".to_string());
+    let libs = env::var("TUNDRA_STATIC_LIBS").unwrap_or("".to_string());
+
+    let native_libs = libs.split(" ");
+
+    println!("cargo:rustc-link-search=native={}", tundra_dir);
+
+    for lib in native_libs {
+        println!("cargo:rustc-link-lib=static={}", lib);
+        println!("cargo:rerun-if-changed={}", lib);
+    }
+}
+
+

--- a/examples/rust/prog/src/main.rs
+++ b/examples/rust/prog/src/main.rs
@@ -1,0 +1,12 @@
+extern crate my_crate;
+
+extern {
+    fn print_hello();
+}
+
+fn main() {
+    unsafe { 
+        print_hello() 
+    }
+    println!("some value {}", my_crate::get_rand())
+}

--- a/examples/rust/shared_lib/Cargo.lock
+++ b/examples/rust/shared_lib/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "shared_lib"
+version = "0.1.0"
+

--- a/examples/rust/shared_lib/Cargo.toml
+++ b/examples/rust/shared_lib/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "shared_lib"
+version = "0.1.0"
+build = "build.rs"
+
+[lib]
+name = "shared_lib"
+crate-type = ["dylib"]

--- a/examples/rust/shared_lib/build.rs
+++ b/examples/rust/shared_lib/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+
+fn main() {
+    let tundra_dir = env::var("TUNDRA_OBJECTDIR").unwrap_or("".to_string());
+    let libs = env::var("TUNDRA_STATIC_LIBS").unwrap_or("".to_string());
+
+    let native_libs = libs.split(" ");
+
+    println!("cargo:rustc-link-search=native={}", tundra_dir);
+
+    for lib in native_libs {
+        println!("cargo:rustc-link-lib=static={}", lib);
+        println!("cargo:rerun-if-changed={}", lib);
+    }
+}
+

--- a/examples/rust/shared_lib/src/lib.rs
+++ b/examples/rust/shared_lib/src/lib.rs
@@ -1,0 +1,10 @@
+extern {
+    fn print_hello();
+}
+
+// foo
+
+#[no_mangle]
+pub extern fn call_me() {
+    unsafe { print_hello() }
+}

--- a/examples/rust/tundra.lua
+++ b/examples/rust/tundra.lua
@@ -1,0 +1,25 @@
+Build {
+	Units = "units.lua",
+	Configs = {
+		{ 
+			Name = "macosx-gcc",
+			DefaultOnHost = "macosx",
+			Tools = { "gcc-osx", "rust" },
+		},
+		{
+			Name = "linux-gcc",
+			DefaultOnHost = "linux",
+			Tools = { "gcc", "rust" },
+		},
+		{
+			Name = "freebsd-clang",
+			DefaultOnHost = "freebsd",
+			Tools = { "clang", "rust" },
+		},
+		{
+			Name = "win64-msvc",
+			DefaultOnHost = "windows",
+			Tools = { "msvc", "rust" },
+		},
+	},
+}

--- a/examples/rust/units.lua
+++ b/examples/rust/units.lua
@@ -1,0 +1,38 @@
+require "tundra.syntax.rust-cargo"
+require "tundra.syntax.glob"
+
+-- Static library that is used by a Rust Program and Rust SharedLibrary
+StaticLibrary {
+	Name = "test_lib",
+	Sources = { "native_lib/lib.c" },
+}
+
+-- This is for Tundra to know about when to (re) build a local crate (which has 
+-- a dependency in the Cargo.toml we can just make sure Tundra knows about the source
+-- files so cargo we be executed if something changes in the crate
+
+local my_crate_sources = { Glob { Dir = "my_crate/src", Extensions = { ".rs" } } }
+
+-- Rust program that uses a local crate (set in Cargo.toml) and a static library
+-- that is built by Tundra and then linked to the final executable by Cargo
+
+RustProgram {
+	Name = "prog",
+	CargoConfig = "prog/Cargo.toml",
+	Sources = { my_crate_sources, 
+				"prog/src/main.rs", "prog/build.rs" },
+	Depends = { "test_lib" },
+}
+
+-- Rust SharedLibrary that uses a static library (test_lib)
+
+RustSharedLibrary {
+	Name = "shared_lib",
+	CargoConfig = "shared_lib/Cargo.toml",
+	Sources = { "shared_lib/src/lib.rs", "shared_lib/build.rs" },
+	Depends = { "test_lib" },
+}
+
+Default "prog"
+Default "shared_lib"
+

--- a/scripts/tundra/syntax/files.lua
+++ b/scripts/tundra/syntax/files.lua
@@ -48,3 +48,17 @@ function hardlink_file(env, src, dst, pass, deps)
     Pass = pass,
   }
 end
+
+function copy_file(env, src, dst, pass, deps)
+  return depgraph.make_node {
+    Env = env,
+    Annotation = "CopyFile $(<)",
+    Action = "$(_COPY_FILE)",
+    InputFiles = { src },
+    OutputFiles = { dst },
+    Dependencies = deps,
+    Pass = pass,
+  }
+end
+
+

--- a/scripts/tundra/syntax/rust-cargo.lua
+++ b/scripts/tundra/syntax/rust-cargo.lua
@@ -1,0 +1,164 @@
+-- rust-cargo.lua - Support for Rust and Cargo 
+
+module(..., package.seeall)
+
+local nodegen  = require "tundra.nodegen"
+local files    = require "tundra.syntax.files"
+local path     = require "tundra.path"
+local util     = require "tundra.util"
+local depgraph = require "tundra.depgraph"
+local native   = require "tundra.native"
+
+_rust_cargo_program_mt = nodegen.create_eval_subclass { }
+_rust_cargo_shared_lib_mt = nodegen.create_eval_subclass { }
+
+function get_extra_deps(data, env) 
+	local libsuffix = { env:get("LIBSUFFIX") }
+  	local sources = data.Sources
+
+	extra_deps = {} 
+
+	for _, dep in util.nil_ipairs(data.Depends) do
+    	if dep.Keyword == "StaticLibrary" then
+			local node = dep:get_dag(env:get_parent())
+			extra_deps[#extra_deps + 1] = node
+			node:insert_output_files(sources, libsuffix)
+		end
+	end
+
+	return extra_deps 
+end
+
+function build_rust_action_cmd_line(env, data, program)
+	local static_libs = ""
+
+	-- build an string with all static libs this code depends on
+
+	for _, dep in util.nil_ipairs(data.Depends) do
+		if dep.Keyword == "StaticLibrary" then
+			local node = dep:get_dag(env:get_parent())
+			static_libs = static_libs .. dep.Decl.Name .. " "
+		end
+	end
+
+	-- The way Cargo sets it's target directory is by using a env variable which is quite ugly but that is the way it works.
+	-- So before running the command we set the target directory of  
+	-- We also set the tundra cmd line as env so we can use that inside the build.rs
+	-- to link with the libs in the correct path
+
+	local target = path.join("$(OBJECTDIR)", "__" .. data.Name)
+
+	local target_dir = "" 
+	local tundra_dir = "$(OBJECTDIR)";
+	local export = "export ";
+	local merge = " ; ";
+
+	if native.host_platform == "windows" then
+		export = "set "
+		merge = "&&"
+	end
+
+	target_dir = export .. "CARGO_TARGET_DIR=" .. target .. merge 
+	tundra_dir = export .. "TUNDRA_OBJECTDIR=" .. tundra_dir .. merge 
+
+	if static_libs ~= "" then
+		-- Remove trailing " "
+		local t = string.sub(static_libs, 1, string.len(static_libs) - 1)
+		static_libs = export .. "TUNDRA_STATIC_LIBS=\"" .. t .. "\"" .. merge 
+	end
+
+	local variant = env:get('CURRENT_VARIANT')
+	local release = ""
+	local output_target = "" 
+	local output_name = ""
+
+	-- Make sure output_name gets prefixed/sufixed correctly
+
+	if program == true then
+		output_name = data.Name .. "$(HOSTPROGSUFFIX)"
+	else
+		output_name = "$(SHLIBPREFIX)" .. data.Name .. "$(HOSTSHLIBSUFFIX)"
+	end
+
+	-- If variant is debug (default) we assume that we should use debug and not release mode
+
+	if variant == "debug" then
+		output_target = path.join(target, "debug$(SEP)" .. output_name) 
+	else
+		output_target = path.join(target, "release$(SEP)" .. output_name) 
+		release = " --release "
+	end
+
+	local action_cmd_line = tundra_dir .. target_dir .. static_libs .. "$(RUST_CARGO) build --manifest-path=" .. data.CargoConfig .. release
+	
+	return action_cmd_line, output_target
+end
+
+function _rust_cargo_program_mt:create_dag(env, data, deps)
+
+	local action_cmd_line, output_target = build_rust_action_cmd_line(env, data, true)
+	local extra_deps = get_extra_deps(data, env)
+
+	local build_node = depgraph.make_node {
+		Env          = env,
+		Pass         = data.Pass,
+		InputFiles   = util.merge_arrays({ data.CargoConfig }, data.Sources),
+		Annotation 	 = path.join("$(OBJECTDIR)", data.Name), 
+		Label        = "Cargo Program $(@)",
+		Action       = action_cmd_line,
+		OutputFiles  = { output_target }, 
+		Dependencies = util.merge_arrays(deps, extra_deps),
+	}
+
+	local dst ="$(OBJECTDIR)" .. "$(SEP)" .. path.get_filename(env:interpolate(output_target))
+	local src = output_target
+
+	-- Copy the output file to the regular $(OBJECTDIR) 
+	return files.copy_file(env, src, dst, data.Pass, { build_node })
+end
+
+function _rust_cargo_shared_lib_mt:create_dag(env, data, deps)
+
+	local action_cmd_line, output_target = build_rust_action_cmd_line(env, data, false)
+	local extra_deps = get_extra_deps(data, env)
+
+	local build_node = depgraph.make_node {
+		Env          = env,
+		Pass         = data.Pass,
+		InputFiles   = util.merge_arrays({ data.CargoConfig }, data.Sources),
+		Annotation 	 = path.join("$(OBJECTDIR)", data.Name), 
+		Label        = "Cargo SharedLibrary $(@)",
+		Action       = action_cmd_line,
+		OutputFiles  = { output_target }, 
+		Dependencies = util.merge_arrays(deps, extra_deps),
+	}
+
+	local dst ="$(OBJECTDIR)" .. "$(SEP)" .. path.get_filename(env:interpolate(output_target))
+	local src = output_target
+
+	-- Copy the output file to the regular $(OBJECTDIR) 
+	return files.copy_file(env, src, dst, data.Pass, { build_node })
+end
+
+local rust_blueprint = {
+  Name = { 
+  	  Type = "string", 
+  	  Required = true, 
+  	  Help = "Name of the project. Must match the name in Cargo.toml" 
+  },
+  CargoConfig = { 
+  	  Type = "string", 
+  	  Required = true, 
+  	  Help = "Path to Cargo.toml" 
+  },
+  Sources = {
+    Required = true,
+    Help = "List of source files",
+    Type = "source_list",
+    ExtensionKey = "RUST_SUFFIXES", 
+  },
+}
+
+nodegen.add_evaluator("RustProgram", _rust_cargo_program_mt, rust_blueprint)
+nodegen.add_evaluator("RustSharedLibrary", _rust_cargo_shared_lib_mt, rust_blueprint)
+

--- a/scripts/tundra/tools/rust.lua
+++ b/scripts/tundra/tools/rust.lua
@@ -1,0 +1,10 @@
+module(..., package.seeall)
+
+function apply(env, options)
+  env:set_many {
+    ["RUST_SUFFIXES"] = { ".rs", },
+    ["RUST_CARGO"] = "cargo",
+    ["RUSTC"] = "rustc",
+  }
+end
+

--- a/src/DagGenerator.cpp
+++ b/src/DagGenerator.cpp
@@ -550,12 +550,12 @@ bool ComputeNodeGuids(const JsonArrayValue* nodes, int32_t* remap_table, TempNod
       }
     }
 
-    if ((!action || action[0] == '\0') && !inputs)
+    const char *annotation = FindStringValue(nobj, "Annotation");
+	if (annotation)
+		HashAddString(&h, annotation);
+
+    if ((!action || action[0] == '\0') && !inputs && !annotation)
     {
-      const char *annotation = FindStringValue(nobj, "Annotation");
-      if (annotation)
-        HashAddString(&h, annotation);
-      else
         return false;
     }
 


### PR DESCRIPTION
The following changes has been made:

* In DagGenerator.cpp if Annotation is set it's always being included when generating the hash. This allows the the Rust setup in an easy way make sure that dag nodes has a unique hash.
* In tools/rust.lua has been added which has the Cargo executable and rustc executable (not currently used)

* Added copy_file in file syntax/files.lua

* Rust-cargo has all the logic to handle everything to build correctly with Tundra. Cargo has some annoying things that it can't take target directory and external libs as command line parameters. This is being worked around by setting env variables on the same commandline as the the Cargo run command so it will be executed in the same process and thus won't collide which each other.

* Cargo will always write a target/(debug/release) directories if with a specified directory. The rust-cargo script writes the output like this t2-output/variant/__project_name/(debug/release) then a copy step of the executable/sharedlib is being done to the t2-ouput/variant directory. This keeps the structure where other Tundra artifacts are generated.

* In examples/rust some basic examples has been added that show how a C lib is being linked to a Rust binary and Rust shared lib. Also the Shared lib depends on an external crate that needs to fetch the dependices from creates.io and this is being tested also.