### PR TITLE
Fix precompiled headers in combination with globbing

### DIFF
--- a/examples/pch/src/pch.h
+++ b/examples/pch/src/pch.h
@@ -22,8 +22,7 @@ struct FibSlow_t<TreePos, 1> {
 };
 
 // Be CAREFUL with high values. 24 is pretty slow on GCC 4.8. Larger amounts will use a ton of RAM
-//inline int SlowDown() { return FibSlow_t<0,24>::value; }
-inline int SlowDown() { return FibSlow_t<0,24>::value; }
+inline int SlowDown() { return FibSlow_t<0,20>::value; }
 
 #include <stdio.h>
 #include "included_in_pch.h"

--- a/examples/pch/tundra.lua
+++ b/examples/pch/tundra.lua
@@ -15,7 +15,7 @@ Build {
 		{
 			Name = "win32-msvc",
 			DefaultOnHost = "windows",
-			Tools = { "msvc-winsdk" },
+			Tools = { "msvc-vs2013" },
 		},
 		{
 			Name = "linux-gcc",

--- a/examples/pch/units.lua
+++ b/examples/pch/units.lua
@@ -1,3 +1,4 @@
+require 'tundra.syntax.glob'
 
 Program {
 	Name = "testpch",
@@ -16,6 +17,7 @@ Program {
 	SourceDir = "src/",
 	Sources = {
 		-- Note that it is OK to include pch.cpp in the Sources list (eg when using globbing), but it is not necessary
+		--"pch.cpp",
 		"main.cpp",
 		"src1.cpp",
 		"src2.cpp",
@@ -24,5 +26,26 @@ Program {
 		"subdir/src5.cpp",
 	},
 }
-
 Default "testpch"
+
+-- This shows how to use precompiled headers with globbing.
+-- It was initially used as a test to get globbing and precompiled headers working together correctly.
+Program {
+	Name = "testpch_glob",
+	PrecompiledHeader = {
+		Source = "src/pch.cpp",
+		Header = "pch.h",
+		Pass = "PchGen",
+	},
+	Includes = {
+		"src",
+	},
+	Sources = {
+		FGlob {
+			Dir = "src",
+			Extensions = { ".c", ".cpp" },
+			Filters = {},
+		}
+	},
+}
+Default "testpch_glob"

--- a/scripts/tundra/tools/generic-cpp.lua
+++ b/scripts/tundra/tools/generic-cpp.lua
@@ -25,11 +25,12 @@ local function generic_cpp_setup(env)
 
     local output_files = { object_fn }
 
+    -- pch_source is run through path.normalize() when it gets setup, so we need to normalize fn here too
     local pch_source = env:get('_PCH_SOURCE', '')
+    local is_pch_source = path.normalize(fn) == pch_source
     local implicit_inputs = nil
     
-    if fn == pch_source then
-      
+    if is_pch_source then
       label = 'Precompiled header'
       pass = nodegen.resolve_pass(env:get('_PCH_PASS', ''))
       action = "$(PCHCOMPILE)"
@@ -39,7 +40,7 @@ local function generic_cpp_setup(env)
         output_files = { "$(_PCH_FILE)" }
       end
 
-    elseif pch_source ~= '' and fn ~= pch_source then
+    elseif pch_source ~= '' and not is_pch_source then
 
       -- It would be good to make all non-pch source files dependent upon the .pch node.
       -- That would require that we generate the .pch node before generating these nodes.


### PR DESCRIPTION
Previously (at least on Windows), one was unable to combine the use of
precompiled headers and globbing. This commit fixes two issues in that
regard:

1. Improve the accuracy of the check for "is the precompiled header
source file included in the list of sources".

2. Fix the check in generic_cpp_setup which determines whether this is THE
precompiled header source file, and if so, applies the special parameters
to it.

Also, added an example to the "pch" example, which demonstrates combining
precompiled headers with globbing. This is more of a test than an example,
and I'm in two minds about whether it's best to leave it in or remove it.