### PR TITLE
Profiler output option (in Chrome Tracing format)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build.checked
 build.mingw
 dists
 .DS_Store
+.vs

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ LIBTUNDRA_SOURCES = \
 	BinaryWriter.cpp BuildQueue.cpp Common.cpp DagGenerator.cpp \
 	Driver.cpp FileInfo.cpp Hash.cpp HashTable.cpp \
 	IncludeScanner.cpp JsonParse.cpp MemAllocHeap.cpp \
-	MemAllocLinear.cpp MemoryMappedFile.cpp PathUtil.cpp \
+	MemAllocLinear.cpp MemoryMappedFile.cpp PathUtil.cpp Profiler.cpp \
 	ScanCache.cpp Scanner.cpp SignalHandler.cpp StatCache.cpp \
 	TargetSelect.cpp Thread.cpp TerminalIo.cpp \
 	ExecUnix.cpp ExecWin32.cpp DigestCache.cpp FileSign.cpp \

--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -11,6 +11,7 @@
 #include "Stats.hpp"
 #include "StatCache.hpp"
 #include "FileSign.hpp"
+#include "Profiler.hpp"
 
 #include <stdio.h>
 
@@ -447,6 +448,7 @@ namespace t2
     {
       Log(kSpam, "Launching pre-action process");
       TimingScope timing_scope(&g_Stats.m_ExecCount, &g_Stats.m_ExecTimeCycles);
+      ProfilerScope prof_scope("Pre-build", job_id);
       result = ExecuteProcess(pre_cmd_line, env_count, env_vars, job_id, echo_cmdline, "(pre-build command)");
       Log(kSpam, "Process return code %d", result.m_ReturnCode);
     }
@@ -455,6 +457,7 @@ namespace t2
     {
       Log(kSpam, "Launching process");
       TimingScope timing_scope(&g_Stats.m_ExecCount, &g_Stats.m_ExecTimeCycles);
+      ProfilerScope prof_scope(annotation, job_id);
       result = ExecuteProcess(cmd_line, env_count, env_vars, job_id, echo_cmdline, annotation);
       Log(kSpam, "Process return code %d", result.m_ReturnCode);
     }
@@ -699,6 +702,7 @@ namespace t2
 
   void BuildQueueInit(BuildQueue* queue, const BuildQueueConfig* config)
   {
+    ProfilerScope prof_scope("Tundra BuildQueueInit", 0);
     CHECK(config->m_MaxExpensiveCount > 0 && config->m_MaxExpensiveCount <= config->m_ThreadCount);
 
     MutexInit(&queue->m_Lock);
@@ -757,6 +761,7 @@ namespace t2
 
   void BuildQueueDestroy(BuildQueue* queue)
   {
+    ProfilerScope prof_scope("Tundra BuildQueueDestroy", 0);
     Log(kDebug, "destroying build queue");
     const BuildQueueConfig* config = &queue->m_Config;
 

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -40,6 +40,7 @@ struct DriverOptions
 #endif
   int         m_ThreadCount;
   const char *m_WorkingDir;
+  const char *m_ProfileOutput;
 };
 
 void DriverOptionsInit(DriverOptions* self);

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -1,0 +1,202 @@
+#include "Profiler.hpp"
+#include "Common.hpp"
+#include "MemAllocLinear.hpp"
+#include "MemAllocHeap.hpp"
+
+#include <stdio.h>
+
+namespace t2
+{
+  const size_t kProfilerThreadMaxEvents = 32 * 1024; // max this # of events per thread
+  const size_t kProfilerThreadStringsSize = kProfilerThreadMaxEvents * 128; // that many bytes of name string storage per thread
+
+  struct ProfilerEvent
+  {
+    uint64_t    m_Time;
+    uint64_t    m_Duration;
+    const char* m_Name;
+    const char* m_Info;
+  };
+
+  struct ProfilerThread
+  {
+    MemAllocLinear  m_ScratchStrings;
+    ProfilerEvent*  m_Events;
+    int             m_EventCount;
+    bool            m_IsBegin;
+  };
+
+  struct ProfilerState
+  {
+    MemAllocHeap    m_Heap;
+    char*           m_FileName;
+    ProfilerThread* m_Threads;
+    int             m_ThreadCount;
+  };
+
+  static ProfilerState s_ProfilerState;
+
+  bool g_ProfilerEnabled;
+
+  void ProfilerInit(const char* fileName, int threadCount)
+  {
+    CHECK(!g_ProfilerEnabled);
+    CHECK(threadCount > 0);
+
+    g_ProfilerEnabled = true;
+
+    s_ProfilerState.m_ThreadCount = threadCount;
+
+    HeapInit(&s_ProfilerState.m_Heap);
+
+    size_t fileNameLen = strlen(fileName);
+    s_ProfilerState.m_FileName = (char*)HeapAllocate(&s_ProfilerState.m_Heap, fileNameLen + 1);
+    memcpy(s_ProfilerState.m_FileName, fileName, fileNameLen + 1);
+
+    s_ProfilerState.m_Threads = HeapAllocateArray<ProfilerThread>(&s_ProfilerState.m_Heap, s_ProfilerState.m_ThreadCount);
+    for (int i = 0; i < s_ProfilerState.m_ThreadCount; ++i)
+    {
+      ProfilerThread& thread = s_ProfilerState.m_Threads[i];
+      thread.m_Events = HeapAllocateArray<ProfilerEvent>(&s_ProfilerState.m_Heap, kProfilerThreadMaxEvents);
+      thread.m_EventCount = 0;
+      LinearAllocInit(&thread.m_ScratchStrings, &s_ProfilerState.m_Heap, kProfilerThreadStringsSize, "profilerStrings");
+      thread.m_IsBegin = false;
+    }
+  }
+
+  static void EscapeString(const char* src, char* dst, int dstSpace)
+  {
+    while (*src && dstSpace > 2) // some input chars might expand into 2 in the output
+    {
+      char c = *src;
+      switch (c)
+      {
+      case '"':
+      case '\\':
+      case '\b':
+      case '\f':
+      case '\n':
+      case '\r':
+      case '\t':
+        *dst++ = '\\'; *dst++ = c; dstSpace -= 2;
+        break;
+      default:
+        if (c >= 32 && c < 126)
+        {
+          *dst++ = c; dstSpace -= 1;
+        }
+      }
+      ++src;
+    }
+    *dst = 0;
+  }
+
+  void ProfilerWriteOutput()
+  {
+    FILE* f = fopen(s_ProfilerState.m_FileName, "w");
+    if (!f)
+    {
+      Log(kWarning, "profiler: failed to write profiler output file into '%s'", s_ProfilerState.m_FileName);
+      return;
+    }
+
+    // See https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit for
+    // Chrome Tracing profiler format description
+
+    fputs("{\n", f);
+    // JSON does not support comments, so emit "how to use this" as a fake string value    
+    fputs("\"instructions_readme\": \"1) Open Chrome, 2) go to chrome://tracing, 3) click Load, 4) navigate to this file.\",\n", f);
+    fputs("\"traceEvents\":[\n", f);
+    for (int i = 0; i < s_ProfilerState.m_ThreadCount; ++i)
+    {
+      const ProfilerThread& thread = s_ProfilerState.m_Threads[i];
+      if (i != 0)
+        fputs(",", f);
+      fprintf(f, "{ \"pid\":1, \"tid\":%d, \"ph\":\"M\", \"name\":\"thread_name\", \"args\": { \"name\":\"%d\" } }\n", i, i);
+      for (int j = 0; j < thread.m_EventCount; ++j)
+      {
+        const ProfilerEvent& evt = thread.m_Events[j];
+        double timeUs = TimerToSeconds(evt.m_Time)*1.0e6;
+        double durUs = TimerToSeconds(evt.m_Duration)*1.0e6;
+        char name[1024];
+        char info[1024];
+        EscapeString(evt.m_Name, name, sizeof(name));
+        EscapeString(evt.m_Info, info, sizeof(info));
+        fprintf(f, ",{ \"pid\":1, \"tid\":%d, \"ts\":%.0f, \"dur\":%.0f, \"ph\":\"X\", \"name\": \"%s\", \"args\": { \"durationMS\":%.0f, \"detail\":\"%s\" }}\n", i, timeUs, durUs, name, durUs*0.001, info);
+      }
+    }
+    fputs("\n]\n", f);
+    fputs("}\n", f);
+
+    fclose(f);
+  }
+
+  void ProfilerDestroy()
+  {
+    if (!g_ProfilerEnabled)
+      return;
+
+    for (int i = 0; i < s_ProfilerState.m_ThreadCount; ++i)
+    {
+      ProfilerThread& thread = s_ProfilerState.m_Threads[i];
+      if (thread.m_IsBegin)
+        ProfilerEndImpl(i);
+    }
+
+    ProfilerWriteOutput();
+
+    for (int i = 0; i < s_ProfilerState.m_ThreadCount; ++i)
+    {
+      ProfilerThread& thread = s_ProfilerState.m_Threads[i];
+      Log(kSpam, "profiler: thread %i had %d events, %.1f KB strings", i, thread.m_EventCount, double(thread.m_ScratchStrings.m_Offset)/1024.0);
+      HeapFree(&s_ProfilerState.m_Heap, thread.m_Events);
+      LinearAllocDestroy(&thread.m_ScratchStrings);
+    }
+    HeapFree(&s_ProfilerState.m_Heap, s_ProfilerState.m_Threads);
+    HeapFree(&s_ProfilerState.m_Heap, s_ProfilerState.m_FileName);
+    HeapDestroy(&s_ProfilerState.m_Heap);
+  }
+
+  void ProfilerBeginImpl(const char* name, int threadIndex)
+  {
+    CHECK(g_ProfilerEnabled);
+    CHECK(threadIndex >= 0 && threadIndex < s_ProfilerState.m_ThreadCount);
+    ProfilerThread& thread = s_ProfilerState.m_Threads[threadIndex];
+    CHECK(!thread.m_IsBegin);
+    thread.m_IsBegin = true;
+    if (thread.m_EventCount >= kProfilerThreadMaxEvents)
+    {
+      Log(kWarning, "profiler: max events (%d) reached on thread %i, '%s' and later won't be recorded", (int)kProfilerThreadMaxEvents, threadIndex, name);
+      return;
+    }
+    ProfilerEvent& evt = thread.m_Events[thread.m_EventCount++];
+    evt.m_Time = TimerGet();
+
+    // split input name by first space
+    const char* nextWord = strchr(name, ' ');
+    if (nextWord == nullptr)
+    {
+      evt.m_Name = StrDup(&thread.m_ScratchStrings, name);
+      evt.m_Info = "";
+    }
+    else
+    {
+      evt.m_Name = StrDupN(&thread.m_ScratchStrings, name, nextWord - name);
+      evt.m_Info = StrDup(&thread.m_ScratchStrings, nextWord + 1);
+    }
+  }
+
+  void ProfilerEndImpl(int threadIndex)
+  {
+    CHECK(g_ProfilerEnabled);
+    CHECK(threadIndex >= 0 && threadIndex < s_ProfilerState.m_ThreadCount);
+    ProfilerThread& thread = s_ProfilerState.m_Threads[threadIndex];
+    CHECK(thread.m_IsBegin);
+    CHECK(thread.m_EventCount > 0);
+    thread.m_IsBegin = false;
+    if (thread.m_EventCount > kProfilerThreadMaxEvents)
+      return;
+    ProfilerEvent& evt = thread.m_Events[thread.m_EventCount-1];
+    evt.m_Duration = TimerGet() - evt.m_Time;
+  }
+}

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -107,12 +107,10 @@ namespace t2
     // JSON does not support comments, so emit "how to use this" as a fake string value    
     fputs("\"instructions_readme\": \"1) Open Chrome, 2) go to chrome://tracing, 3) click Load, 4) navigate to this file.\",\n", f);
     fputs("\"traceEvents\":[\n", f);
+    fputs("{ \"cat\":\"\", \"pid\":1, \"tid\":0, \"ts\":0, \"ph\":\"M\", \"name\":\"process_name\", \"args\": { \"name\":\"tundra\" } }\n", f);
     for (int i = 0; i < s_ProfilerState.m_ThreadCount; ++i)
     {
       const ProfilerThread& thread = s_ProfilerState.m_Threads[i];
-      if (i != 0)
-        fputs(",", f);
-      fprintf(f, "{ \"pid\":1, \"tid\":%d, \"ph\":\"M\", \"name\":\"thread_name\", \"args\": { \"name\":\"%d\" } }\n", i, i);
       for (int j = 0; j < thread.m_EventCount; ++j)
       {
         const ProfilerEvent& evt = thread.m_Events[j];

--- a/src/Profiler.hpp
+++ b/src/Profiler.hpp
@@ -1,0 +1,51 @@
+#ifndef PROFILER_HPP
+#define PROFILER_HPP
+
+namespace t2
+{
+  extern bool g_ProfilerEnabled;
+
+  // Simple non-hierarchical profiler; that dumps output into Google Chrome Tracing
+  // JSON format.
+  //
+  // Begin/End a profiling event with ProfilerBegin and ProfilerEnd, or automatically
+  // with ProfilerScope struct. Events can not nest (profiler is not hierarchical).
+  // String passed into the event will be copied, and split into "name" and "detail" parts on first
+  // space character.
+
+  void ProfilerInit(const char* fileName, int threadCount);
+  void ProfilerDestroy();
+
+  void ProfilerBeginImpl(const char* name, int threadIndex);
+  void ProfilerEndImpl(int threadIndex);
+
+  inline void ProfilerBegin(const char* name, int threadIndex)
+  {
+    if (g_ProfilerEnabled)
+      ProfilerBeginImpl(name, threadIndex);
+  }
+
+  inline void ProfilerEnd(int threadIndex)
+  {
+    if (g_ProfilerEnabled)
+      ProfilerEndImpl(threadIndex);
+  }
+
+  struct ProfilerScope
+  {
+    int m_ThreadIndex;
+    ProfilerScope(const char* name, int threadIndex)
+    {
+      m_ThreadIndex = threadIndex;
+      ProfilerBegin(name, threadIndex);
+    }
+
+    ~ProfilerScope()
+    {
+      ProfilerEnd(m_ThreadIndex);
+    }
+  };
+
+}
+
+#endif

--- a/src/ScanCache.cpp
+++ b/src/ScanCache.cpp
@@ -9,6 +9,7 @@
 #include "MemoryMappedFile.hpp"
 #include "SortedArrayUtil.hpp"
 #include "HashTable.hpp"
+#include "Profiler.hpp"
 
 #include <algorithm>
 #include <time.h>
@@ -416,6 +417,7 @@ static void SaveRecord(
 bool ScanCacheSave(ScanCache* self, const char* fn, MemAllocHeap* heap)
 {
   TimingScope timing_scope(nullptr, &g_Stats.m_ScanCacheSaveTime);
+  ProfilerScope prof_scope("Tundra SaveScanCache", 0);
 
   MemAllocLinear* scratch = self->m_Allocator;
 

--- a/vs2012/libtundra/libtundra.vcxproj
+++ b/vs2012/libtundra/libtundra.vcxproj
@@ -94,7 +94,6 @@
     <ClInclude Include="..\..\src\DagData.hpp" />
     <ClInclude Include="..\..\src\DagGenerator.hpp" />
     <ClInclude Include="..\..\src\DigestCache.hpp" />
-    <ClInclude Include="..\..\src\dlmalloc.h" />
     <ClInclude Include="..\..\src\Driver.hpp" />
     <ClInclude Include="..\..\src\Exec.hpp" />
     <ClInclude Include="..\..\src\FileInfo.hpp" />
@@ -129,7 +128,6 @@
     <ClCompile Include="..\..\src\ConditionVar.cpp" />
     <ClCompile Include="..\..\src\DagGenerator.cpp" />
     <ClCompile Include="..\..\src\DigestCache.cpp" />
-    <ClCompile Include="..\..\src\dlmalloc.c" />
     <ClCompile Include="..\..\src\Driver.cpp" />
     <ClCompile Include="..\..\src\ExecUnix.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>

--- a/vs2012/libtundra/libtundra.vcxproj
+++ b/vs2012/libtundra/libtundra.vcxproj
@@ -108,6 +108,7 @@
     <ClInclude Include="..\..\src\Mutex.hpp" />
     <ClInclude Include="..\..\src\NodeState.hpp" />
     <ClInclude Include="..\..\src\PathUtil.hpp" />
+    <ClInclude Include="..\..\src\Profiler.hpp" />
     <ClInclude Include="..\..\src\ReadWriteLock.hpp" />
     <ClInclude Include="..\..\src\ScanCache.hpp" />
     <ClInclude Include="..\..\src\ScanData.hpp" />
@@ -146,6 +147,7 @@
     <ClCompile Include="..\..\src\MemAllocLinear.cpp" />
     <ClCompile Include="..\..\src\MemoryMappedFile.cpp" />
     <ClCompile Include="..\..\src\PathUtil.cpp" />
+    <ClCompile Include="..\..\src\Profiler.cpp" />
     <ClCompile Include="..\..\src\ReadWriteLock.cpp" />
     <ClCompile Include="..\..\src\ScanCache.cpp" />
     <ClCompile Include="..\..\src\Scanner.cpp" />

--- a/vs2012/libtundra/libtundra.vcxproj.filters
+++ b/vs2012/libtundra/libtundra.vcxproj.filters
@@ -126,6 +126,9 @@
     <ClInclude Include="..\..\src\DigestCache.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\Profiler.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\BinaryWriter.cpp">
@@ -213,6 +216,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ReadWriteLock.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Profiler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/vs2012/libtundra/libtundra.vcxproj.filters
+++ b/vs2012/libtundra/libtundra.vcxproj.filters
@@ -45,9 +45,6 @@
     <ClInclude Include="..\..\src\DagGenerator.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\dlmalloc.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\Driver.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -141,9 +138,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\DagGenerator.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\dlmalloc.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\Driver.cpp">


### PR DESCRIPTION
Optional `-p` / `--profile` flag dumps Google Chrome Tracing formatted profiling output to the given file.

Fixed VS2012 project too (`dlmalloc` files are gone now).

![profilershot](https://user-images.githubusercontent.com/348087/35679452-c5ad53c0-075f-11e8-9c8f-fc7c8e8af23b.png)
