### PR TITLE
Stop having two different implementations for file & glob signatures …

### DIFF
--- a/scripts/tundra/dagsave.lua
+++ b/scripts/tundra/dagsave.lua
@@ -319,12 +319,7 @@ local function save_signatures(w, accessed_lua_files)
   w:begin_array("FileSignatures")
   for _, fn in ipairs(accessed_lua_files) do
     w:begin_object()
-    local stat = native.stat_file(fn)
-    if not stat.exists then
-      errorf("accessed file %s is gone: %s", fn, err)
-    end
     w:write_string(fn, "File")
-    w:write_number(stat.timestamp, "Timestamp")
     w:end_object()
   end
   w:end_array()
@@ -334,12 +329,6 @@ local function save_signatures(w, accessed_lua_files)
   for _, glob in ipairs(globs) do
     w:begin_object()
     w:write_string(glob.Path, "Path")
-    w:begin_array("Files")
-    for _, fn in ipairs(glob.Files) do w:write_string(fn) end
-    w:end_array()
-    w:begin_array("SubDirs")
-    for _, fn in ipairs(glob.SubDirs) do w:write_string(fn) end
-    w:end_array()
     w:end_object()
   end
   w:end_array()

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -17,6 +17,7 @@
 #include "HashTable.hpp"
 #include "Hash.hpp"
 #include "Profiler.hpp"
+#include "FileSign.hpp"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -249,84 +250,12 @@ static bool DriverCheckDagSignatures(Driver* self)
     }
   }
 
-  // Helper for directory iteration + memory allocation of strings.  We need to
-  // buffer the filenames as we need them in sorted order to ensure the results
-  // are consistent between runs.
-  struct IterContext
-  {
-    MemAllocLinear       *m_Allocator;
-    MemAllocHeap         *m_Heap;
-    Buffer<const char *>  m_Dirs;
-    Buffer<const char *>  m_Files;
-
-    void Init(MemAllocHeap* heap, MemAllocLinear* linear)
-    {
-      m_Allocator = linear;
-      m_Heap      = heap;
-      BufferInit(&m_Dirs);
-      BufferInit(&m_Files);
-    }
-
-    void Destroy()
-    {
-      BufferDestroy(&m_Files, m_Heap);
-      BufferDestroy(&m_Dirs, m_Heap);
-    }
-
-    static void Callback(void* user_data, const FileInfo& info, const char* path)
-    {
-      IterContext* self = (IterContext*) user_data;
-      char* data = StrDup(self->m_Allocator, path);
-      Buffer<const char*>* target = info.IsDirectory() ? &self->m_Dirs : &self->m_Files;
-      BufferAppendOne(target, self->m_Heap, data);
-    }
-
-    static int SortStringPtrs(const void* l, const void* r)
-    {
-      return strcmp(*(const char**)l, *(const char**)r);
-    }
-  };
-
   // Check directory listing fingerprints
   // Note that the digest computation in here must match the one in LuaListDirectory
   // The digests computed there are stored in the signature block by Lua code.
   for (const DagGlobSignature& sig : dag_data->m_GlobSignatures)
   {
-    const char* path = sig.m_Path;
-
-    // Set up to rewind allocator for each loop iteration
-    MemAllocLinearScope mem_scope(&self->m_Allocator);
-
-    // Set up context
-    IterContext ctx;
-    ctx.Init(&self->m_Heap, &self->m_Allocator);
-
-    // Get directory data
-    ListDirectory(path, &ctx, IterContext::Callback);
-
-    // Sort data
-    qsort(ctx.m_Dirs.m_Storage, ctx.m_Dirs.m_Size, sizeof(const char*), IterContext::SortStringPtrs);
-    qsort(ctx.m_Files.m_Storage, ctx.m_Files.m_Size, sizeof(const char*), IterContext::SortStringPtrs);
-
-    // Compute digest - note that this has to match DagGenerator.cpp
-    HashState h;
-    HashInit(&h);
-    for (const char* p : ctx.m_Dirs)
-    {
-      HashAddPath(&h, p);
-      HashAddSeparator(&h);
-    }
-
-    for (const char* p : ctx.m_Files)
-    {
-      HashAddPath(&h, p);
-      HashAddSeparator(&h);
-    }
-
-    HashDigest digest;
-    HashFinalize(&h, &digest);
-
-    ctx.Destroy();
+    HashDigest digest = CalculateGlobSignatureFor(sig.m_Path, &self->m_Heap, &self->m_Allocator);
 
     // Compare digest with the one stored in the signature block
     if (0 != memcmp(&digest, &sig.m_Digest, sizeof digest))

--- a/src/FileSign.hpp
+++ b/src/FileSign.hpp
@@ -2,6 +2,7 @@
 #define FILESIGN_HPP
 
 #include "Common.hpp"
+#include "Hash.hpp"
 
 namespace t2
 {
@@ -9,6 +10,8 @@ namespace t2
 struct HashState;
 struct StatCache;
 struct DigestCache;
+struct MemAllocHeap;
+struct MemAllocLinear;
 
 void ComputeFileSignature(
   HashState*          out,                  // out
@@ -18,6 +21,10 @@ void ComputeFileSignature(
   uint32_t            fn_hash,
   const uint32_t      sha_extension_hashes[],
   int                 sha_extension_hash_count);
+
+  HashDigest CalculateGlobSignatureFor(const char* path, MemAllocHeap* heap, MemAllocLinear* scratch);
+
 }
+
 
 #endif


### PR DESCRIPTION
…that have to be kept in sync. Always use the backend implementation.

This is more friendly to 3rd party frontends, that now also no longer have to worry about having identical globbing and filtering behaviour.