### PR TITLE
Avoid crashing when there is no DAG data.

### DIFF
--- a/src/DigestCache.cpp
+++ b/src/DigestCache.cpp
@@ -9,7 +9,7 @@
 namespace t2
 {
 
-void DigestCacheInit(DigestCache* self, size_t heap_size, const char* filename)
+void DigestCacheInit(DigestCache* self, size_t heap_size)
 {
   ReadWriteLockInit(&self->m_Lock);
 
@@ -21,7 +21,10 @@ void DigestCacheInit(DigestCache* self, size_t heap_size, const char* filename)
   HashTableInit(&self->m_Table, &self->m_Heap);
 
   self->m_AccessTime = time(nullptr);
+}
 
+void DigestCacheOpen(DigestCache* self, const char* filename)
+{
   MmapFileMap(&self->m_StateFile, filename);
   if (MmapFileValid(&self->m_StateFile))
   {

--- a/src/DigestCache.hpp
+++ b/src/DigestCache.hpp
@@ -58,7 +58,8 @@ namespace t2
     uint64_t                m_AccessTime;
   };
 
-  void DigestCacheInit(DigestCache* self, size_t heap_size, const char* filename);
+  void DigestCacheInit(DigestCache* self, size_t heap_size);
+  void DigestCacheOpen(DigestCache* self, const char* filename);
 
   void DigestCacheDestroy(DigestCache* self);
 

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -169,10 +169,12 @@ bool DriverInitData(Driver* self)
 {
   ProfilerScope prof_scope("Tundra InitData", 0);
 
+  DigestCacheInit(&self->m_DigestCache, MB(128));
+
   if (!DriverPrepareDag(self, s_DagFileName))
     return false;
 
-  DigestCacheInit(&self->m_DigestCache, MB(128), self->m_DagData->m_DigestCacheFileName);
+  DigestCacheOpen(&self->m_DigestCache, self->m_DagData->m_DigestCacheFileName);
 
   LoadFrozenData<StateData>(self->m_DagData->m_StateFileName, &self->m_StateFile, &self->m_StateData);
 


### PR DESCRIPTION
We would try to clean up the digest cache not having initialized it.