### PR TITLE
Fix uninitialized variable m_QuickstartGen

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -65,16 +65,17 @@ void DriverOptionsInit(DriverOptions* self)
   self->m_DisplayStats    = false;
   self->m_GenDagOnly      = false;
   self->m_Quiet           = false;
+  self->m_IdeGen          = false;
   self->m_Clean           = false;
   self->m_Rebuild         = false;
-  self->m_IdeGen          = false;
   self->m_DebugSigning    = false;
   self->m_ContinueOnError = false;
+  self->m_QuickstartGen   = false;
   self->m_ThreadCount     = GetCpuCount();
   self->m_WorkingDir      = nullptr;
   self->m_DAGFileName     = ".tundra2.dag";
   self->m_ProfileOutput   = nullptr;
-  #if defined(TUNDRA_WIN32)
+#if defined(TUNDRA_WIN32)
   self->m_RunUnprotected  = false;
 #endif
 }


### PR DESCRIPTION
I noticed this on an x64 build on VS 2017 15.9.8

I also re-ordered the variables so that it's easier to spot an uninitialized one.