### PR TITLE
Ensure DriverOptions.m_QuickstartGen defaults to false

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -77,6 +77,7 @@ void DriverOptionsInit(DriverOptions* self)
   #if defined(TUNDRA_WIN32)
   self->m_RunUnprotected  = false;
 #endif
+  self->m_QuickstartGen   = false;
 }
 
 // Helper routine to load frozen data into RAM via memory mapping


### PR DESCRIPTION
I noticed that on my machine (windows 10 64-bit), the latest pre-built version of tundra2 would run the quickstart generation even if I did not supply the -Q commandline option. Net result: whenever I tried building an existing project, it would stomp over the existing tundra.lua and then exit :)

Looks like this is down to an uninitialized variable. This change (not compiled, not test-run) ought to resolve that problem. I believe that this change should fix it.

(In the future it might be better to move the initialization to use C++11 style member initializers in the .hpp file - much easier to spot this sort of mistakes then)