### PR TITLE
Added support for targets with ISPC

### DIFF
--- a/examples/ispc/tundra.lua
+++ b/examples/ispc/tundra.lua
@@ -2,9 +2,8 @@
 local common = {
   Env = {
     ISPCOPTS = {
-      "--target=sse4 --cpu=corei7",
       { "--arch=x86"; Config = "win32-*" },
-      { "--arch=x86-64";	Config = { "win64-*", "macosx-*" } },
+      { "--arch=x86-64"; Config = { "win64-*", "macosx-*" } },
     },
     CPPPATH = {
       -- Pick up generated ISPC headers from the object directory
@@ -26,13 +25,19 @@ Build {
 			Name = "win32-msvc",
 			DefaultOnHost = "windows",
 			Tools = { "msvc-vs2010", "ispc" },
-      Inherit = common,
+      		Inherit = common,
 		},
-    Config {
+		Config {
+			Name = "linucx-gcc",
+			DefaultOnHost = "linux",
+			Tools = { "gcc", "ispc" },
+      		Inherit = common,
+		},
+    	Config {
 			Name = "macosx-clang",
 			DefaultOnHost = "macosx",
 			Tools = { "clang-osx", "ispc" },
-      Inherit = common,
+      		Inherit = common,
     },
 	},
 }

--- a/examples/ispc/units.lua
+++ b/examples/ispc/units.lua
@@ -5,9 +5,10 @@ Program {
 	Sources = {
 		"main.c",
 		ISPC {
-      Pass   = "IspcGen",
-      Source = "lanes.ispc"
-    },
+			Pass   = "IspcGen",
+			Source = "lanes.ispc",
+			Targets = "sse4,avx2"
+    	},
 	},
 }
 

--- a/scripts/tundra/syntax/ispc.lua
+++ b/scripts/tundra/syntax/ispc.lua
@@ -2,7 +2,7 @@
 
 module(..., package.seeall)
 
-local path     = require "tundra.path"
+local path = require "tundra.path"
 
 DefRule {
   Name = "ISPC",
@@ -10,16 +10,52 @@ DefRule {
 
   Blueprint = {
     Source = { Required = true, Type = "string" },
+    Targets = { Required = false, Type = "string" },
   },
 
   Setup = function (env, data)
     local src = data.Source
     local base_name = path.drop_suffix(src) 
-    local objFile = "$(OBJECTDIR)$(SEP)" .. base_name .. "__" .. path.get_extension(src):sub(2) .. "$(OBJECTSUFFIX)"
-    local hFile = "$(OBJECTDIR)$(SEP)" .. base_name .. "_ispc.h"
-    return {
-      InputFiles = { src },
-      OutputFiles = { objFile, hFile },
-    }
+    local ext = path.get_extension(src):sub(2)
+    local obj_file = "$(OBJECTDIR)$(SEP)" .. base_name .. "__" .. ext .. "$(OBJECTSUFFIX)"
+    local h_file = "$(OBJECTDIR)$(SEP)" .. base_name .. "_ispc.h"
+    -- Add the targets to the ISPC options if we have targets set
+    if data.Targets ~= nil then
+      env:append("ISPCOPTS", "--target=" .. data.Targets)
+    end
+    -- If we don't declare Targets or if it only contains one target we assume single output from ISPC
+    if data.Targets == nil or not string.find(data.Targets, ",") then
+      return {
+        InputFiles = { src },
+        OutputFiles = { obj_file, h_file },
+      }
+    else
+      -- build a table with the targets we have without potentially width added (such as avx2-i16x16)
+      local output_files = {}
+      table.insert(output_files, obj_file)
+      table.insert(output_files, h_file)
+
+      for str in string.gmatch(data.Targets, "([^,]+)") do
+        -- if name is target-<width> we skip the width specifiery when building the output name
+        local target_name
+        if string.find(str, "-") then
+          target_name = string.sub(str, 1, string.find(str, "-")-1)
+        else
+          target_name = str
+        end
+
+        -- construct a name that looks like name__ispc_<target>.o/ and name_ispc_<target>.h
+        local obj_file = "$(OBJECTDIR)$(SEP)" .. base_name .. "__" .. ext .. "_" ..  target_name .. "$(OBJECTSUFFIX)"
+        local h_file = "$(OBJECTDIR)$(SEP)" .. base_name .. target_name .. "_ispc.h"
+
+        table.insert(output_files, obj_file)
+        table.insert(output_files, h_file)
+      end
+
+      return {
+        InputFiles = { src },
+        OutputFiles = output_files,
+      }
+    end
   end,
 }


### PR DESCRIPTION
This PR adds support to specify different targets when using ISPC like this

```lua
ISPC {
    Pass = "IspcGen",
    Source = "lanes.ispc",
    Targets = "sse4,avx2"
},
```
When setting several targets to ISPC the compiler will generate one object file and one header for each target. The default function that one calls in this mode will do a run-time selection and call the appropriate one depending on instruction set the CPU supports. The user can chose to not use this function but instead calling `function_name_<target>` such as `foobar_avx2` and do the detection themselves.

Changes in this PR does a bunch of things
* First we need to tell Tundra about the output files the compiler generates which is the meat of this change.
* `Targets` is optional, so the user can chose to ignore it and use the old behavior if wanted, but to support more than on target then `Targets` parameter needs to be used.
* Added Linux target to the ISPC example
* Some minor cleanup
* Added `sse4,avx2` to the ISPC example
