### PR TITLE
Add support for VS 2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # dummy
 name: Build
-on: [pull_request, push]
+on: [pull_request]
 jobs:
   build-test-linux:
     strategy:

--- a/scripts/tundra/ide/msvc-common.lua
+++ b/scripts/tundra/ide/msvc-common.lua
@@ -402,11 +402,10 @@ function msvc_generator:generate_project(project, all_projects)
   p:write(' DefaultTargets="Build"')
 
   -- This doesn't seem to change any behaviour, but this is the default
-  -- value when creating a makefile project from VS2013, VS2015, VS2017,
-  -- and VS2019 wizards.
-  if VERSION_YEAR == '2019' then
-    p:write(' ToolsVersion="16.0"')
-  elseif VERSION_YEAR == '2017' then
+  -- value when creating a makefile project from VS2013, VS2015, VS2017
+  -- wizards.
+  -- MS state that ToolsVersion is obsolete from VS2019 onwards.
+  if VERSION_YEAR == '2017' then
     p:write(' ToolsVersion="15.0"')
   elseif VERSION_YEAR == '2015' then
     p:write(' ToolsVersion="14.0"')
@@ -430,13 +429,12 @@ function msvc_generator:generate_project(project, all_projects)
   p:write('\t</ItemGroup>', LF)
 
   p:write('\t<PropertyGroup Label="Globals">', LF)
-  if VERSION_YEAR == '2019' then
-    p:write('\t\t<VCProjectVersion>16.0</VCProjectVersion>', LF)
-  elseif VERSION_YEAR == '2017' then
+  -- Undocumented, appears to only exist in VS2017 projects.
+  if VERSION_YEAR == '2017' then
     p:write('\t\t<VCProjectVersion>15.0</VCProjectVersion>', LF)
   end
   p:write('\t\t<ProjectGuid>{', project.Guid, '}</ProjectGuid>', LF)
-  if VERSION_YEAR == '2019' or VERSION_YEAR == '2017' then
+  if VERSION_YEAR == '2022' or VERSION_YEAR == '2019' or VERSION_YEAR == '2017' then
     p:write('\t\t<Keyword>Win32Proj</Keyword>', LF)
   else
     p:write('\t\t<Keyword>MakefileProj</Keyword>', LF)
@@ -462,24 +460,26 @@ function msvc_generator:generate_project(project, all_projects)
   for _, tuple in ipairs(self.config_tuples) do
     p:write('\t<PropertyGroup Condition="\'$(Configuration)|$(Platform)\'==\'', tuple.MsvcName, '\'" Label="Configuration">', LF)
     p:write('\t\t<ConfigurationType>Makefile</ConfigurationType>', LF)
-    p:write('\t\t<UseDebugLibraries>true</UseDebugLibraries>', LF) -- I have no idea what this setting affects
+    p:write('\t\t<UseDebugLibraries>true</UseDebugLibraries>', LF) -- This seems to be a master switch for multiple debug features
     if VERSION_YEAR == '2012' then
-      p:write('\t\t<PlatformToolset>v110</PlatformToolset>', LF) -- I have no idea what this setting affects
+      p:write('\t\t<PlatformToolset>v110</PlatformToolset>', LF) -- Use MSVC compiler toolset version 11.0 (VS2012)
     elseif VERSION_YEAR == '2013' then
-      p:write('\t\t<PlatformToolset>v120</PlatformToolset>', LF) -- I have no idea what this setting affects
+      p:write('\t\t<PlatformToolset>v120</PlatformToolset>', LF) -- Use MSVC compiler toolset version 12.0 (VS2013)
     elseif VERSION_YEAR == '2015' then
-      p:write('\t\t<PlatformToolset>v140</PlatformToolset>', LF) -- I have no idea what this setting affects
+      p:write('\t\t<PlatformToolset>v140</PlatformToolset>', LF) -- Use MSVC compiler toolset version 14.0 (VS2015)
     elseif VERSION_YEAR == '2017' then
-      p:write('\t\t<PlatformToolset>v141</PlatformToolset>', LF) -- I have no idea what this setting affects
+      p:write('\t\t<PlatformToolset>v141</PlatformToolset>', LF) -- Use MSVC compiler toolset version 14.1 (VS2017)
     elseif VERSION_YEAR == '2019' then
-      p:write('\t\t<PlatformToolset>v142</PlatformToolset>', LF) -- I have no idea what this setting affects
+      p:write('\t\t<PlatformToolset>v142</PlatformToolset>', LF) -- Use MSVC compiler toolset version 14.2 (VS2019)
+    elseif VERSION_YEAR == '2022' then
+      p:write('\t\t<PlatformToolset>v143</PlatformToolset>', LF) -- Use MSVC compiler toolset version 14.3 (VS2022)
     end
     p:write('\t</PropertyGroup>', LF)
   end
 
   p:write('\t<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />', LF)
 
-  if VERSION_YEAR == '2019' or VERSION_YEAR == '2017' then
+  if VERSION_YEAR == '2022' or VERSION_YEAR == '2019' or VERSION_YEAR == '2017' then
     for _, tuple in ipairs(self.config_tuples) do
       p:write('\t<ImportGroup Label="PropertySheets" Condition="\'$(Configuration)|$(Platform)\'==\'', tuple.MsvcName, '\'">', LF)
       p:write('\t\t<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists(\'$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props\')" Label="LocalAppDataPlatform" />', LF)

--- a/scripts/tundra/ide/msvc143.lua
+++ b/scripts/tundra/ide/msvc143.lua
@@ -1,0 +1,7 @@
+-- Microsoft Visual Studio 2022 Solution/Project file generation
+
+module(..., package.seeall)
+
+local msvc_common = require "tundra.ide.msvc-common"
+
+msvc_common.setup("12.00", "2022")

--- a/scripts/tundra/tools/msvc-vs2022.lua
+++ b/scripts/tundra/tools/msvc-vs2022.lua
@@ -1,0 +1,8 @@
+
+module(..., package.seeall)
+
+local vscommon = require "tundra.tools.msvc-vscommon-next"
+
+function apply(env, options)
+  vscommon.apply_msvc_visual_studio("2022", env, options)
+end

--- a/scripts/tundra/tools/msvc-vscommon-next.lua
+++ b/scripts/tundra/tools/msvc-vscommon-next.lua
@@ -102,6 +102,10 @@ function apply_msvc_visual_studio(version, env, options)
   local platform_type = options.PlatformType --default empty ({empty} | store | uwp)
   local sdk_version = options.SdkVersion --default from vcvarsall.bat (otherwise request a specific version through this option)
   local installation_path = options.InstallationPath or "C:\\Program Files (x86)\\Microsoft Visual Studio"
+  -- VS2022 is 64-bit and gets installed into Program Files.
+  if (!options.InstallationPath and (version == "2022")) {
+    installation_path = "C:\\Program Files\\Microsoft Visual Studio"
+  }
   local vs_product = options.Product
   local vcvarsall_bat = options.VCVarsPath --override the search strategy and use a specific 'vcvars' bat file
   local search_set = {}

--- a/scripts/tundra/tools/msvc-vscommon-next.lua
+++ b/scripts/tundra/tools/msvc-vscommon-next.lua
@@ -103,9 +103,10 @@ function apply_msvc_visual_studio(version, env, options)
   local sdk_version = options.SdkVersion --default from vcvarsall.bat (otherwise request a specific version through this option)
   local installation_path = options.InstallationPath or "C:\\Program Files (x86)\\Microsoft Visual Studio"
   -- VS2022 is 64-bit and gets installed into Program Files.
-  if (!options.InstallationPath and (version == "2022")) {
+  if not options.InstallationPath and (version == "2022") then
     installation_path = "C:\\Program Files\\Microsoft Visual Studio"
-  }
+  end
+
   local vs_product = options.Product
   local vcvarsall_bat = options.VCVarsPath --override the search strategy and use a specific 'vcvars' bat file
   local search_set = {}


### PR DESCRIPTION
Spent some time adding support for VS 2022, since it seemed pretty straightforward to get this up and running.

One thing of note, is that Microsoft have recently marked the `ToolsVersion` attribute as being obsolete.

> The MSBuild ToolsVersion attribute on the Project element in Visual Studio and MSBuild project files is considered obsolete in Visual Studio 2019 and later; you can safely delete it.

[ToolsVersion MSBuild Docs](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-toolset-toolsversion?view=vs-2022)

I've removed VS 2019 from the check that sets that attribute, as it seemed unnecessary, given what Microsoft has said.

`VCProjectVersion` seems to be completely undocumented, and I couldn't seem to find a VS 2019 or VS 2022 C++ project that has that element inside of it.
Seems like it was just a VS 2017 thing, not sure.
Didn't notice any side effects of that being removed in my tests, on VS 2022.

Let me know if you want anything updated or changed on this, and I'll get it sorted.

(Please excuse the CI workflow commits, that was me mucking about doing some tests, I've reverted them. I am hoping to do a squash & merge so that history won't linger around in here, let me know what you would prefer).