### PR TITLE
Fixed incorrect threads count on Linux

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -24,6 +24,10 @@
 #include <sys/sysctl.h>
 #endif
 
+#if defined(TUNDRA_LINUX)
+#include <thread>
+#endif
+
 #if defined(TUNDRA_WIN32)
 #include <windows.h>
 #include <ctype.h>
@@ -341,6 +345,8 @@ int GetCpuCount()
   SYSTEM_INFO si;
   GetSystemInfo(&si);
   return (int) si.dwNumberOfProcessors;
+#elif defined(TUNDRA_LINUX)
+  return (int)std::thread::hardware_concurrency();
 #else
   long nprocs_max = sysconf(_SC_NPROCESSORS_CONF);
   if (nprocs_max < 0)


### PR DESCRIPTION
On my Linux system (ArchLinux) using `sysconf(_SC_NPROCESSORS_CONF);` will return 128 while my actual thread count is 32. This will cause Tundra to print an warning that number of threads gets clamped to 64, but after that will then crash.

This PR doesn't fix the underlying crash, but instead uses C++11 `std::thread::hardware_concurrency();` to get the number of hw threads in the system and this returns the correct value and now everything works as it should, but there is still another issue that makes tundra crash when thread count ends up being 128.

I know we use C++11 for Linux, but I'm unsure about the other targets. If that is true in all cases then it might be worth considering using this code path on all targets.