### PR TITLE
Added msvc-clang tools

### DIFF
--- a/scripts/tundra/tools/msvc-clang.lua
+++ b/scripts/tundra/tools/msvc-clang.lua
@@ -1,0 +1,17 @@
+module(..., package.seeall)
+
+local vslatest = require "tundra.tools.msvc-latest"
+
+function apply(env, options)
+  local extra = {
+    Clang = true
+  }
+
+  vslatest.apply(env, options, extra)
+
+  env:set_many{
+    ["CC"] = "clang-cl",
+    ["CXX"] = "clang-cl",
+    ["LD"] = "lld-link"
+  }
+end

--- a/scripts/tundra/tools/msvc-latest.lua
+++ b/scripts/tundra/tools/msvc-latest.lua
@@ -326,6 +326,19 @@ function apply(env, options, extra)
     env_lib[#env_lib + 1] = native_path.join(vc_tools_dir, "lib\\onecore\\" .. target_arch)
   end
 
+  if extra.Clang then
+    -- file:///C:/Program%20Files%20(x86)/Microsoft%20Visual%20Studio/2022/BuildTools/VC/Tools/Llvm
+    if target_arch == "x64" then
+      env_path[#env_path + 1] = native_path.join(vs_install_dir, "VC\\Tools\\Llvm\\x64\\bin")
+    elseif target_arch == "arm64" then
+      env_path[#env_path + 1] = native_path.join(vs_install_dir, "VC\\Tools\\Llvm\\ARM64\\bin")
+    elseif target_arch == "x86" then
+      env_path[#env_path + 1] = native_path.join(vs_install_dir, "VC\\Tools\\Llvm\\bin")
+    else
+      error("msvc-clang: target architecutre '" .. target_arch .. "' not supported")
+    end
+  end
+
   -- Force MSPDBSRV.EXE (fix for issue with cl.exe running in parallel and otherwise corrupting PDB files)
   -- These options where added to Visual C++ in Visual Studio 2013. They do not exist in older versions.
   env:set("CCOPTS", "/FS")


### PR DESCRIPTION
Now that Microsoft is actually distributing Clang as part of Visual Studio you can use clang instead of Visual C++ when you want to. There's more than one way to do this and I've just taken the easy path here to get something going.

In this first iteration, I've used the clang-cl and lld-link frontends because it allowed me to reuse the msvc base. This might not be desirable as the whole point of using clang is to gain access to clang features while this could be nice to have I'm wondering if people wouldn't rather see a more _native_ clang interface?

With that said, given the following `tundra.lua`:

```lua
Build {
  Configs = {
    {
      Name = "win64-clang",
      DefaultOnHost = "windows",
      Tools = {
        "msvc-clang"
      }
    }
  },
  Units = {
    function()
      Program {
        Name = "test",
        Sources = {
          "test.cc"
        }
      }

      Default("test")
    end
  }
}
```

...we can build this program:

```cc
#include <cstdio>

int main()
{
  printf("clang version %s\n", __clang_version__);
  return 0;
}
```

...which will output:

```
clang version 16.0.5
```

Toughts?