### PR TITLE
Fixes for max CPU count of 64

### DIFF
--- a/src/BuildQueue.cpp
+++ b/src/BuildQueue.cpp
@@ -735,15 +735,10 @@ namespace t2
     queue->m_ExpensiveWaitCount = 0;
     queue->m_ExpensiveWaitList  = HeapAllocateArray<NodeState*>(heap, capacity);
 
+    queue->m_Threads = HeapAllocateArrayZeroed<ThreadId>(config->m_Heap, config->m_ThreadCount);
+    queue->m_ThreadState = HeapAllocateArrayZeroed<ThreadState>(config->m_Heap, config->m_ThreadCount);
+
     CHECK(queue->m_Queue);
-
-    if (queue->m_Config.m_ThreadCount > kMaxBuildThreads)
-    {
-      Log(kWarning, "too many build threads (%d) - clamping to %d",
-          queue->m_Config.m_ThreadCount, kMaxBuildThreads);
-
-      queue->m_Config.m_ThreadCount = kMaxBuildThreads;
-    }
 
     Log(kDebug, "build queue initialized; ring buffer capacity = %u", queue->m_QueueCapacity);
 
@@ -796,6 +791,9 @@ namespace t2
 
     CondDestroy(&queue->m_WorkAvailable);
     MutexDestroy(&queue->m_Lock);
+
+    HeapFree(config->m_Heap, queue->m_ThreadState);
+    HeapFree(config->m_Heap, queue->m_Threads);
 
     // Unblock all signals on the main thread.
     SignalHandlerSetCondition(nullptr);

--- a/src/BuildQueue.hpp
+++ b/src/BuildQueue.hpp
@@ -17,11 +17,6 @@ namespace t2
   struct StatCache;
   struct DigestCache;
 
-  enum
-  {
-    kMaxBuildThreads = 64
-  };
-
   struct BuildQueueConfig
   {
     enum
@@ -73,8 +68,8 @@ namespace t2
     int32_t            m_PendingNodeCount;
     int32_t            m_FailedNodeCount;
     int32_t            m_CurrentPassIndex;
-    ThreadId           m_Threads[kMaxBuildThreads];
-    ThreadState        m_ThreadState[kMaxBuildThreads];
+    ThreadId          *m_Threads;
+    ThreadState       *m_ThreadState;
     int32_t            m_ExpensiveRunning;
     int32_t            m_ExpensiveWaitCount;
     NodeState        **m_ExpensiveWaitList;

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -24,10 +24,6 @@
 #include <sys/sysctl.h>
 #endif
 
-#if defined(TUNDRA_LINUX)
-#include <thread>
-#endif
-
 #if defined(TUNDRA_WIN32)
 #include <windows.h>
 #include <ctype.h>
@@ -346,9 +342,7 @@ int GetCpuCount()
   GetSystemInfo(&si);
   return (int) si.dwNumberOfProcessors;
 #elif defined(TUNDRA_LINUX)
-  return (int)std::thread::hardware_concurrency();
-#else
-  long nprocs_max = sysconf(_SC_NPROCESSORS_CONF);
+  long nprocs_max = sysconf(_SC_NPROCESSORS_ONLN);
   if (nprocs_max < 0)
     CroakErrno("couldn't get CPU count");
   return (int) nprocs_max;

--- a/src/Exec.hpp
+++ b/src/Exec.hpp
@@ -15,7 +15,7 @@ namespace t2
     bool    m_WasSignalled;
   };
 
-  void ExecInit(void);
+  void ExecInit(int thread_count);
 
   ExecResult ExecuteProcess(
         const char*         cmd_line,

--- a/src/ExecUnix.cpp
+++ b/src/ExecUnix.cpp
@@ -37,7 +37,7 @@ static void SetFdNonBlocking(int fd)
 		CroakErrno("couldn't unblock fd %d", fd);
 }
 
-void ExecInit(void)
+void ExecInit(int thread_count)
 {
 	TerminalIoInit();
 }

--- a/src/ExecWin32.cpp
+++ b/src/ExecWin32.cpp
@@ -45,7 +45,7 @@ static char              s_TemporaryDir[MAX_PATH];
 static DWORD             s_TundraPid;
 static Mutex             s_FdMutex;
 
-static HANDLE s_TempFiles[kMaxBuildThreads];
+static HANDLE           *s_TempFiles;
 
 static HANDLE AllocFd(int job_id)
 {
@@ -176,8 +176,9 @@ static char UTF8_WindowsEnvironment[128*1024];
 
 static size_t g_Win32EnvCount;
 
-void ExecInit(void)
+void ExecInit(int thread_count)
 {
+  s_TempFiles = (HANDLE*) calloc(thread_count, sizeof s_TempFiles[0]);
   s_TundraPid = GetCurrentProcessId();
 
   if (0 == GetTempPathA(sizeof(s_TemporaryDir), s_TemporaryDir))

--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -65,8 +65,8 @@ void HashAddStringFoldCase(HashState* self, const char* path)
     char c = *path++;
     if (c == 0)
       return;
-      c = FoldCase(c);
-      HashUpdate(self, &c, 1);
+    c = FoldCase(c);
+    HashUpdate(self, &c, 1);
   }
 }
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -334,7 +334,7 @@ int main(int argc, char* argv[])
 
   uint64_t start_time = TimerGet();
 
-  ExecInit();
+  ExecInit(options.m_ThreadCount);
 
   if (options.m_WorkingDir)
   {


### PR DESCRIPTION
Change static arrays to dynamically allocated arrays. I think we can afford two allocations per run of the tool.

The root cause was a bug where a copy of the configuration was taken before the clamp was applied.

However I'm still not sure why some Linux distributions lie and pretend to have 128 CPUs.

Fixes #346 