### PR TITLE
Forward default nodes as lookup table in ide file generation

### DIFF
--- a/scripts/tundra/boot.lua
+++ b/scripts/tundra/boot.lua
@@ -35,7 +35,7 @@ end
 --
 -- Usage:
 --   foo = bench("foo", foo) -- benchmark function foo
-function _G.bench(name, fn) 
+function _G.bench(name, fn)
   return function (...)
     local t1 = native.get_timer()
     local result = { fn(...) }
@@ -73,12 +73,12 @@ local function make_default_env(build_data, add_unfiltered_vars)
     mod.apply_host(default_env)
   end
 
-  -- Add any unfiltered entries from the build data's Env and ReplaceEnv to the 
+  -- Add any unfiltered entries from the build data's Env and ReplaceEnv to the
   -- default environment. For config environments, this will be false, because we
   -- want to wait until the config's tools have run before adding any user
   -- customizations.
   if add_unfiltered_vars then
-    if build_data.Env then 
+    if build_data.Env then
       nodegen.append_filtered_env_vars(default_env, build_data.Env, nil, true)
     end
     if build_data.ReplaceEnv then
@@ -137,7 +137,17 @@ function generate_ide_files(build_script_fn, ide_script)
     build_data.Configs,
     env)
 
+  -- Lookup table for default nodes
+  local default_nodes = {}
+  for _, v in ipairs(node_bindings) do
+    if v.DefaultNodes then
+      for _, default_node in pairs(v.DefaultNodes) do
+        default_nodes[default_node] = true
+      end
+    end
+  end
+
   -- Pass the build tuples directly to the generator and let it write
   -- files.
-  nodegen.generate_ide_files(build_tuples, build_data.DefaultNodes, raw_nodes, env, raw_data.IdeGenerationHints, ide_script)
+  nodegen.generate_ide_files(build_tuples, default_nodes, raw_nodes, env, raw_data.IdeGenerationHints, ide_script)
 end

--- a/scripts/tundra/boot.lua
+++ b/scripts/tundra/boot.lua
@@ -35,7 +35,7 @@ end
 --
 -- Usage:
 --   foo = bench("foo", foo) -- benchmark function foo
-function _G.bench(name, fn)
+function _G.bench(name, fn) 
   return function (...)
     local t1 = native.get_timer()
     local result = { fn(...) }
@@ -78,7 +78,7 @@ local function make_default_env(build_data, add_unfiltered_vars)
   -- want to wait until the config's tools have run before adding any user
   -- customizations.
   if add_unfiltered_vars then
-    if build_data.Env then
+    if build_data.Env then 
       nodegen.append_filtered_env_vars(default_env, build_data.Env, nil, true)
     end
     if build_data.ReplaceEnv then

--- a/scripts/tundra/boot.lua
+++ b/scripts/tundra/boot.lua
@@ -73,7 +73,7 @@ local function make_default_env(build_data, add_unfiltered_vars)
     mod.apply_host(default_env)
   end
 
-  -- Add any unfiltered entries from the build data's Env and ReplaceEnv to the
+  -- Add any unfiltered entries from the build data's Env and ReplaceEnv to the 
   -- default environment. For config environments, this will be false, because we
   -- want to wait until the config's tools have run before adding any user
   -- customizations.

--- a/scripts/tundra/ide/codelite.lua
+++ b/scripts/tundra/ide/codelite.lua
@@ -599,7 +599,7 @@ function codelite_generator:generate_project(project, all_projects)
 end
 
 
-function codelite_generator:generate_files(ngen, config_tuples, raw_nodes, env, default_names, hints, ide_script)
+function codelite_generator:generate_files(ngen, config_tuples, raw_nodes, env, default_nodes, hints, ide_script)
   assert(config_tuples and #config_tuples > 0)
 
   if not hints then

--- a/scripts/tundra/ide/msvc-common.lua
+++ b/scripts/tundra/ide/msvc-common.lua
@@ -785,7 +785,7 @@ function msvc_generator:generate_project_user(project)
   p:close()
 end
   
-function msvc_generator:generate_files(ngen, config_tuples, raw_nodes, env, default_names, hints, ide_script)
+function msvc_generator:generate_files(ngen, config_tuples, raw_nodes, env, default_nodes, hints, ide_script)
   assert(config_tuples and #config_tuples > 0)
 
   if not hints then

--- a/scripts/tundra/ide/xcode3.lua
+++ b/scripts/tundra/ide/xcode3.lua
@@ -699,7 +699,7 @@ local function generate_shellscript(env)
   os.execute("chmod +x " .. filename)
 end
 
-function xcode_generator:generate_files(ngen, config_tuples, raw_nodes, env, default_names)
+function xcode_generator:generate_files(ngen, config_tuples, raw_nodes, env, default_nodes)
   assert(config_tuples and #config_tuples > 0)
 
   -- TODO: Set the first default config as default

--- a/scripts/tundra/ide/xcode5.lua
+++ b/scripts/tundra/ide/xcode5.lua
@@ -833,7 +833,7 @@ local function make_meta_projects(ide_script)
   }
 end
 
-function xcode_generator:generate_files(ngen, config_tuples, raw_nodes, env, default_names, hints, ide_script)
+function xcode_generator:generate_files(ngen, config_tuples, raw_nodes, env, default_nodes, hints, ide_script)
   assert(config_tuples and #config_tuples > 0)
 
   hints = hints or {}

--- a/scripts/tundra/ide/xcode7.lua
+++ b/scripts/tundra/ide/xcode7.lua
@@ -1161,7 +1161,7 @@ local function write_schemes(schemes_dir, projects, config_tuples, xcodeproj_nam
   m:write('</plist>\n')
 end
 
-function xcode_generator:generate_files(ngen, config_tuples, raw_nodes, env, default_names, hints, ide_script)
+function xcode_generator:generate_files(ngen, config_tuples, raw_nodes, env, default_nodes, hints, ide_script)
   assert(config_tuples and #config_tuples > 0)
 
   hints = hints or {}

--- a/scripts/tundra/nodegen.lua
+++ b/scripts/tundra/nodegen.lua
@@ -813,12 +813,12 @@ function replace_filtered_env_vars(env, values_to_replace, build_id, exclusive)
   end
 end
 
-function generate_ide_files(config_tuples, default_names, raw_nodes, env, hints, ide_script)
+function generate_ide_files(config_tuples, default_nodes, raw_nodes, env, hints, ide_script)
   local state = new_generator { default_env = env }
   assert(state.default_env)
   create_unit_map(state, raw_nodes)
   local backend_fn = assert(ide_backend)
-  backend_fn(state, config_tuples, raw_nodes, env, default_names, hints, ide_script)
+  backend_fn(state, config_tuples, raw_nodes, env, default_nodes, hints, ide_script)
 end
 
 function set_ide_backend(backend_fn)


### PR DESCRIPTION
This PR forwards default nodes in IDE file generation code. As explained in this issue https://github.com/deplinenoise/tundra/issues/345

I cannot use utility function `make_lookup_table` because I'm building a lookup table from an _array of arrays_. I made sure though that it does this the same way it would do it if you flattened the array and then passed it to `make_lookup_table`.